### PR TITLE
Feature/validate json schema

### DIFF
--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -137,6 +137,17 @@ def simplify(schema):
     return _helper_simplify(schema, schema)
 
 
+def validation_errors(schema):
+    """
+    Given a dict, returns any known JSON Schema validation errors. If there are none,
+    implies that the dict is a valid JSON Schema.
+    :param schema: dict
+    :return: [String, ...]
+    """
+
+    return []
+
+
 def from_sql(sql_type, nullable):
     _format = None
     if sql_type == 'timestamp with time zone':

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -175,6 +175,9 @@ def validation_errors(schema):
 
     errors = []
 
+    if not isinstance(schema, dict):
+        errors.append('Parameter `schema` is not a dict, instead found: {}'.format(type(schema)))
+
     try:
         if not _valid_schema_version(schema):
             errors.append('Schema version must be Draft 4. Found: {}'.format('$schema'))

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -10,11 +10,11 @@ def test_is_object():
     assert json_schema.is_object({})
 
 
-def test_simplify_empty():
+def test_simplify__empty():
     assert json_schema.simplify({}) == {}
 
 
-def test_simplify_types_into_arrays():
+def test_simplify__types_into_arrays():
     assert \
         json_schema.simplify(
             {'type': 'null'}
@@ -31,7 +31,7 @@ def test_simplify_types_into_arrays():
                 'a': {'type': ['string']}}}
 
 
-def test_simplify_complex():
+def test_simplify__complex():
     assert \
         json_schema.simplify({
             'type': ['null', 'array'],
@@ -96,7 +96,7 @@ def test_simplify_complex():
                                         'format': 'date-time'}}}}}}}}
 
 
-def test_simplify_refs():
+def test_simplify__refs():
     assert \
         json_schema.simplify(
             {
@@ -179,7 +179,7 @@ def test_simplify_refs():
                         'state': {'type': ['string']}}}}}
 
 
-def test_simplify_refs_invalid_format():
+def test_simplify__refs__invalid_format():
     with pytest.raises(Exception, match=r'Invalid format.*'):
         json_schema.simplify(
             {
@@ -199,7 +199,7 @@ def test_simplify_refs_invalid_format():
                     'singleton': {'$ref': '#definitions/singleton'}}})
 
 
-def test_simplify_refs_missing():
+def test_simplify__refs__missing():
     with pytest.raises(Exception, match=r'.*not found.*'):
         json_schema.simplify(
             {
@@ -218,7 +218,7 @@ def test_simplify_refs_missing():
                     'singleton': {'$ref': '#/definitions/foo/bar'}}})
 
 
-def test_simplify_refs_circular():
+def test_simplify__refs__circular():
     with pytest.raises(Exception, match=r'.*is recursive.*'):
         json_schema.simplify(
             {
@@ -258,7 +258,7 @@ def test_simplify_refs_circular():
                     'person': {'$ref': '#/definitions/person'}}})
 
 
-def test_validation_errors_valid_schemas():
+def test_validation_errors():
     assert json_schema.validation_errors({}) \
            == []
 
@@ -306,7 +306,7 @@ def _non_string_elements(x):
     return problems
 
 
-def test_validation_errors_invalid_schemas():
+def test_validation_errors__invalid_schemas():
     invalid_type_test = json_schema.validation_errors({'type': 'well this should not work'})
     assert invalid_type_test
     assert not _non_string_elements(invalid_type_test)
@@ -339,7 +339,7 @@ def test_validation_errors_invalid_schemas():
     assert not _non_string_elements(non_standard_schema_version)
 
 
-def test_validation_errors_invalid_draft_version():
+def test_validation_errors__invalid_draft_version():
     draft_3 = json_schema.validation_errors({'$schema': 'http://json-schema.org/draft-03/schema#'})
     assert draft_3
     assert not _non_string_elements(draft_3)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -256,3 +256,98 @@ def test_simplify_refs_circular():
 
                 'properties': {
                     'person': {'$ref': '#/definitions/person'}}})
+
+
+def test_validation_errors_valid_schemas():
+    assert json_schema.validation_errors({}) \
+           == []
+
+    assert json_schema.validation_errors({'type': 'null'}) \
+           == []
+
+    assert json_schema.validation_errors({'type': ['object'],
+                                          'properties': {
+                                              'a': {'type': 'string'}}}) \
+           == []
+
+    assert json_schema.validation_errors(
+        {
+            'definitions': {
+                'address': {
+                    'type': 'object',
+                    'properties': {
+                        'street_address': {'type': 'string'},
+                        'city': {'type': 'string'},
+                        'state': {'type': 'string'}
+                    },
+                    'required': ['street_address', 'city', 'state']
+                }
+            },
+
+            'type': 'object',
+
+            'properties': {
+                'billing_address': {'$ref': '#/definitions/address'},
+                'shipping_address': {'$ref': '#/definitions/address'}}}) \
+           == []
+
+
+def _non_string_elements(x):
+    """
+    Simple helper to check that all values of x are string. Returns all non string elements as (position, element).
+    :param x: Iterable
+    :return: [(int, !String), ...]
+    """
+
+    problems = []
+    for i in range(0, len(x)):
+        if not isinstance(x[i], str):
+            problems.append((i, x[i]))
+    return problems
+
+
+def test_validation_errors_invalid_schemas():
+    invalid_type_test = json_schema.validation_errors({'type': 'well this should not work'})
+    assert invalid_type_test
+    assert not _non_string_elements(invalid_type_test)
+
+    recursive_schema_test = json_schema.validation_errors({
+        'definitions': {
+            'person': {
+                'type': 'object',
+                'properties': {
+                    'name': {'type': 'string'},
+                    'children': {
+                        'type': 'array',
+                        'items': {'$ref': '#/definitions/person'},
+                        'default': []
+                    }
+                }
+            }
+        },
+
+        'type': 'object',
+
+        'properties': {
+            'person': {'$ref': '#/definitions/person'}}})
+
+    assert recursive_schema_test
+    assert not _non_string_elements(recursive_schema_test)
+
+    non_standard_schema_version = json_schema.validation_errors({'$schema': 'clearly not a valid schema version'})
+    assert non_standard_schema_version
+    assert not _non_string_elements(non_standard_schema_version)
+
+
+def test_validation_errors_invalid_draft_version():
+    draft_3 = json_schema.validation_errors({'$schema': 'http://json-schema.org/draft-03/schema#'})
+    assert draft_3
+    assert not _non_string_elements(draft_3)
+
+    draft_6 = json_schema.validation_errors({'$schema': 'http://json-schema.org/draft-06/schema#'})
+    assert draft_6
+    assert not _non_string_elements(draft_6)
+
+    draft_7 = json_schema.validation_errors({'$schema': 'http://json-schema.org/draft-07/schema#'})
+    assert draft_7
+    assert not _non_string_elements(draft_7)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from target_postgres import json_schema
@@ -304,6 +306,27 @@ def _non_string_elements(x):
         if not isinstance(x[i], str):
             problems.append((i, x[i]))
     return problems
+
+
+def test_validation_errors__invalid_objects():
+    def _invalid_type_ex(ret):
+        return re.match(r'.*not a dict.*', ret[0])
+
+    non_dict_object__int = json_schema.validation_errors(12345)
+    assert _invalid_type_ex(non_dict_object__int)
+    assert not _non_string_elements(non_dict_object__int)
+
+    non_dict_object__string = json_schema.validation_errors('woah no')
+    assert _invalid_type_ex(non_dict_object__string)
+    assert not _non_string_elements(non_dict_object__string)
+
+    non_dict_object__tuple = json_schema.validation_errors(('hello', 'world'))
+    assert _invalid_type_ex(non_dict_object__tuple)
+    assert not _non_string_elements(non_dict_object__tuple)
+
+    non_dict_object__list = json_schema.validation_errors([1, 2, 3])
+    assert _invalid_type_ex(non_dict_object__list)
+    assert not _non_string_elements(non_dict_object__list)
 
 
 def test_validation_errors__invalid_schemas():

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,9 +1,11 @@
 import io
+from copy import deepcopy
 from datetime import datetime
 from unittest.mock import patch
 
 import psycopg2
 import psycopg2.extras
+import pytest
 
 from target_postgres import main
 from target_postgres import singer_stream
@@ -127,6 +129,16 @@ def assert_records(conn, records, table_name, pks, match_pks=False):
 
             if match_pks:
                 assert sorted(list(persisted_records.keys())) == sorted(records_pks)
+
+
+def test_loading__invalid__configuration__schema():
+    stream = CatStream(1)
+    stream.schema = deepcopy(stream.schema)
+    stream.schema['schema']['type'] = 'invalid type for a JSON Schema'
+
+    with pytest.raises(Exception, match=r'.*invalid JSON Schema instance.*'):
+        main(CONFIG, input_stream=stream)
+
 
 def test_loading_simple(db_cleanup):
     stream = CatStream(100)

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -140,7 +140,7 @@ def test_loading__invalid__configuration__schema():
         main(CONFIG, input_stream=stream)
 
 
-def test_loading_simple(db_cleanup):
+def test_loading__simple(db_cleanup):
     stream = CatStream(100)
     main(CONFIG, input_stream=stream)
 


### PR DESCRIPTION
# Motivation
https://github.com/datamill-co/target-postgres/issues/20

The user experience for a broken JSON Schema is fairly poor. This PR seeks to improve the overall experience for the end user by detecting broken/invalid schemas and aborting immediately instead of trying to swallow exceptions etc.

## Suggested Musical Pairing
https://soundcloud.com/talkingheads/stay-up-late-remastered?in=talkingheads/sets/once-in-a-lifetime-the-talking