### PR TITLE
Feature/validate streamed data against known json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Run `target-postgres` against a [Singer](https://singer.io) stream.
 
 It ignores "STATE" type Singer messages.
 
+### Configuration
+#### Invalid Records
+- `invalid_records_detect`: Optional `Boolean`
+  - Defaults to `true`
+  - Include `false` in your config to disable `target-postgres` from crashing on invalid records
+- `invalid_records_threshold`: Optional `Integer`
+  - Defaults to `0`
+  - Include a positive value `n` in your config to allow for `target-postgres` to encounter at most `n` invalid records
+    per stream before giving up.
+
 ## Known Limitations
 - Requires a [JSON Schema](https://json-schema.org/) for every stream.
 - Only string, string with date-time format, integer, number, boolean, object, and array types with or without null are supported. Arrays can have any of the other types listed, including objects as types within items. 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ A [Singer](https://singer.io/) postgres target, for use with Singer streams gene
 
 ## Usage
 
-Create a config file with postgres connection information and target postgres schema.
+Create a [JSON config file](#configjson) similar to the following:
 
 ```json
 {
   "postgres_host": "locahost",
-  "postgres_port": 5432,
   "postgres_database": "my_analytics",
   "postgres_username": "myuser",
   "postgres_password": "1234",
@@ -27,23 +26,26 @@ Create a config file with postgres connection information and target postgres sc
 }
 ```
 
-Run `target-postgres` against a [Singer](https://singer.io) stream.
+Then run `target-postgres` against a [Singer](https://singer.io) stream:
 
 ```sh
-	tap-something | target-postgres --config config.json
+  tap-something | target-postgres --config config.json
 ```
 
-It ignores "STATE" type Singer messages.
+NOTE: It ignores "STATE" type Singer messages.postgres connection information and target postgres schema.
 
-### Configuration
-#### Invalid Records
-- `invalid_records_detect`: Optional `Boolean`
-  - Defaults to `true`
-  - Include `false` in your config to disable `target-postgres` from crashing on invalid records
-- `invalid_records_threshold`: Optional `Integer`
-  - Defaults to `0`
-  - Include a positive value `n` in your config to allow for `target-postgres` to encounter at most `n` invalid records
-    per stream before giving up.
+### Config.json
+
+| Field | Type | Default | Details |
+| ----- | ---- | ------- | ------- |
+| `postgres_host` |`["string", "null"]` | `"localhost"` | |
+| `postgres_port` | `["integer", "null"]`|  `5432` | |
+| `postgres_database` | `["string"]`|  `N/A` | |
+| `postgres_username` | `["string", "null"]` |  `"postgres"` | |
+| `postgres_password` | `["string", "null"]`|  `null` | |
+| `postgres_schema` | `["string", "null"]` |  `"public"` | |
+| `invalid_records_detect` | `["boolean", "null"]`| `true` | Include `false` in your config to disable `target-postgres` from crashing on invalid records |
+| `invalid_records_threshold` | `["integer", "null"]` | `0` | Include a positive value `n` in your config to allow for `target-postgres` to encounter at most `n` invalid records per stream before giving up. |
 
 ## Known Limitations
 - Requires a [JSON Schema](https://json-schema.org/) for every stream.

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -33,7 +33,7 @@ def flush_streams(streams, target, force=False):
 def report_invalid_records(streams):
     for stream_buffer in streams.values():
         if stream_buffer.peek_invalid_records():
-            LOGGER.error("Invalid records detected for stream {}: {}".format(
+            LOGGER.warn("Invalid records detected for stream {}: {}".format(
                 stream_buffer.stream,
                 stream_buffer.peek_invalid_records()
             ))

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -78,7 +78,10 @@ def line_handler(streams, target, max_batch_rows, max_batch_size, line):
             raise Exception('A record for stream {} was encountered before a corresponding schema'
                 .format(line_data['stream']))
 
-        streams[line_data['stream']].add_record_message(line_data)
+        message = streams[line_data['stream']].add_record_message(line_data)
+        if message:
+            raise Exception('Adding record failed',message)
+
     elif line_data['type'] == 'ACTIVATE_VERSION':
         if 'stream' not in line_data:
             raise Exception('`stream` is a required key: {}'.format(line))

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -78,9 +78,7 @@ def line_handler(streams, target, max_batch_rows, max_batch_size, line):
             raise Exception('A record for stream {} was encountered before a corresponding schema'
                 .format(line_data['stream']))
 
-        message = streams[line_data['stream']].add_record_message(line_data)
-        if message:
-            raise Exception('Adding record failed',message)
+        streams[line_data['stream']].add_record_message(line_data)
 
     elif line_data['type'] == 'ACTIVATE_VERSION':
         if 'stream' not in line_data:

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -3,6 +3,13 @@ import arrow
 
 from target_postgres.pysize import get_size
 
+
+class Error(Exception):
+    """
+    Raise when there is an Exception with Singer Streams.
+    """
+
+
 SINGER_RECEIVED_AT = '_sdc_received_at'
 SINGER_BATCHED_AT = '_sdc_batched_at'
 SINGER_SEQUENCE = '_sdc_sequence'
@@ -11,17 +18,22 @@ SINGER_PK = '_sdc_primary_key'
 SINGER_SOURCE_PK_PREFIX = '_sdc_source_key_'
 SINGER_LEVEL = '_sdc_level_{}_id'
 
+
 class BufferedSingerStream(object):
     def __init__(self,
                  stream,
                  schema,
                  key_properties,
                  *args,
+                 invalid_records_detect=True,
+                 invalid_records_threshold=0,
                  max_rows=200000,
-                 max_buffer_size=104857600, # 100MB
+                 max_buffer_size=104857600,  # 100MB
                  **kwargs):
         self.update_schema(schema, key_properties)
         self.stream = stream
+        self.invalid_records_detect = invalid_records_detect
+        self.invalid_records_threshold = invalid_records_threshold
         self.max_rows = max_rows
         self.max_buffer_size = max_buffer_size
 

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -1,6 +1,5 @@
 from jsonschema import Draft4Validator, FormatChecker
 from jsonschema.exceptions import ValidationError
-import arrow
 
 from target_postgres.pysize import get_size
 

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -4,7 +4,7 @@ from jsonschema.exceptions import ValidationError
 from target_postgres.pysize import get_size
 
 
-class Error(Exception):
+class SingerStreamError(Exception):
     """
     Raise when there is an Exception with Singer Streams.
     """
@@ -97,7 +97,7 @@ class BufferedSingerStream(object):
             self.__count += 1
         elif self.invalid_records_detect \
                 and len(self.invalid_records) >= self.invalid_records_threshold:
-            raise Error('Invalid records detected above threshold: {}. See `.args` for details.'.format(
+            raise SingerStreamError('Invalid records detected above threshold: {}. See `.args` for details.'.format(
                 self.invalid_records_threshold
             ), self.invalid_records)
 

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -110,3 +110,6 @@ class BufferedSingerStream(object):
         self.__size = 0
         self.__count = 0
         return _buffer
+
+    def peek_invalid_records(self):
+        return self.invalid_records

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -97,9 +97,10 @@ class BufferedSingerStream(object):
             self.__count += 1
         elif self.invalid_records_detect \
                 and len(self.invalid_records) >= self.invalid_records_threshold:
-            raise SingerStreamError('Invalid records detected above threshold: {}. See `.args` for details.'.format(
-                self.invalid_records_threshold
-            ), self.invalid_records)
+            raise SingerStreamError(
+                'Invalid records detected above threshold: {}. See `.args` for details.'.format(
+                    self.invalid_records_threshold),
+                self.invalid_records)
 
     def peek_buffer(self):
         return self.__buffer

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -191,6 +191,24 @@ class CatStream(FakeStream):
             'adoption': adoption
         }
 
+class InvalidCatStream(CatStream):
+    def generate_record(self):
+        record = CatStream.generate_record(self)
+
+        if chance.boolean(likelihood=50):
+            record['adoption'] = ['invalid', 'adoption']
+        elif chance.boolean(likelihood=50):
+            record['age'] = 'very invalid age'
+        elif chance.boolean(likelihood=50):
+            record['adoption']['immunizations'] = {
+                'type': chance.pickone(['a', 'b', 'c']),
+                'date_administered': ['clearly', 'not', 'a', 'date']
+            }
+        else:
+            record['name'] = 22/7
+
+        return record
+
 def clear_db():
     with psycopg2.connect(**TEST_DB) as conn:
         with conn.cursor() as cur:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -199,7 +199,7 @@ class InvalidCatStream(CatStream):
             record['adoption'] = ['invalid', 'adoption']
         elif chance.boolean(likelihood=50):
             record['age'] = 'very invalid age'
-        elif chance.boolean(likelihood=50):
+        elif record['adoption'] and chance.boolean(likelihood=50):
             record['adoption']['immunizations'] = {
                 'type': chance.pickone(['a', 'b', 'c']),
                 'date_administered': ['clearly', 'not', 'a', 'date']

--- a/tests/test_BufferedSingerStream.py
+++ b/tests/test_BufferedSingerStream.py
@@ -1,6 +1,6 @@
 import pytest
 
-from target_postgres.singer_stream import BufferedSingerStream, Error
+from target_postgres.singer_stream import BufferedSingerStream, SingerStreamError
 from fixtures import CatStream, InvalidCatStream, CATS_SCHEMA
 
 
@@ -24,7 +24,7 @@ def test_add_record_message__invalid_record():
     singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
                                          CATS_SCHEMA['schema'],
                                          CATS_SCHEMA['key_properties'])
-    with pytest.raises(Error):
+    with pytest.raises(SingerStreamError):
         singer_stream.add_record_message(stream.generate_record_message())
 
     assert singer_stream.peek_invalid_records()
@@ -55,7 +55,7 @@ def test_add_record_message__invalid_record__cross_threshold():
     singer_stream.add_record_message(stream.generate_record_message())
     singer_stream.add_record_message(stream.generate_record_message())
 
-    with pytest.raises(Error):
+    with pytest.raises(SingerStreamError):
         singer_stream.add_record_message(stream.generate_record_message())
 
     assert singer_stream.peek_invalid_records()

--- a/tests/test_BufferedSingerStream.py
+++ b/tests/test_BufferedSingerStream.py
@@ -1,0 +1,66 @@
+import pytest
+
+from target_postgres.singer_stream import BufferedSingerStream, Error
+from fixtures import CatStream, CATS_SCHEMA
+
+
+def test_init():
+    assert BufferedSingerStream(CATS_SCHEMA['stream'],
+                                CATS_SCHEMA['schema'],
+                                CATS_SCHEMA['key_properties'])
+
+
+def test_add_record_message():
+    stream = CatStream(10)
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'])
+    assert singer_stream.add_record_message(stream.generate_record_message()) is None
+
+
+def test_add_record_message__invalid_record():
+    stream = CatStream(10)
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'])
+    with pytest.raises(Error):
+        record = stream.generate_record_message()
+        record['record']['name'] = 22 / 7
+
+        singer_stream.add_record_message(record)
+
+
+def test_add_record_message__invalid_record__detection_off():
+    stream = CatStream(10)
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'],
+                                         invalid_records_detect=False)
+
+    record = stream.generate_record_message()
+    record['record']['name'] = 22 / 7
+
+    singer_stream.add_record_message(record)
+
+
+def test_add_record_message__invalid_record__cross_threshold():
+    stream = CatStream(10)
+
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'],
+                                         invalid_records_threshold=3)
+
+    record = stream.generate_record_message()
+    record['record']['name'] = 22 / 7
+    singer_stream.add_record_message(record)
+
+    record = stream.generate_record_message()
+    record['record']['age'] = 'not an age'
+    singer_stream.add_record_message(record)
+
+    with pytest.raises(Error):
+        record = stream.generate_record_message()
+        record['record']['adoption'] = [1, 2, 'not a kitty cat']
+
+        singer_stream.add_record_message(record)

--- a/tests/test_BufferedSingerStream.py
+++ b/tests/test_BufferedSingerStream.py
@@ -1,7 +1,7 @@
 import pytest
 
 from target_postgres.singer_stream import BufferedSingerStream, Error
-from fixtures import CatStream, CATS_SCHEMA
+from fixtures import CatStream, InvalidCatStream, CATS_SCHEMA
 
 
 def test_init():
@@ -19,48 +19,34 @@ def test_add_record_message():
 
 
 def test_add_record_message__invalid_record():
-    stream = CatStream(10)
+    stream = InvalidCatStream(10)
     singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
                                          CATS_SCHEMA['schema'],
                                          CATS_SCHEMA['key_properties'])
     with pytest.raises(Error):
-        record = stream.generate_record_message()
-        record['record']['name'] = 22 / 7
-
-        singer_stream.add_record_message(record)
+        singer_stream.add_record_message(stream.generate_record_message())
 
 
 def test_add_record_message__invalid_record__detection_off():
-    stream = CatStream(10)
+    stream = InvalidCatStream(10)
     singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
                                          CATS_SCHEMA['schema'],
                                          CATS_SCHEMA['key_properties'],
                                          invalid_records_detect=False)
 
-    record = stream.generate_record_message()
-    record['record']['name'] = 22 / 7
-
-    singer_stream.add_record_message(record)
+    singer_stream.add_record_message(stream.generate_record_message())
 
 
 def test_add_record_message__invalid_record__cross_threshold():
-    stream = CatStream(10)
+    stream = InvalidCatStream(10)
 
     singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
                                          CATS_SCHEMA['schema'],
                                          CATS_SCHEMA['key_properties'],
                                          invalid_records_threshold=3)
 
-    record = stream.generate_record_message()
-    record['record']['name'] = 22 / 7
-    singer_stream.add_record_message(record)
-
-    record = stream.generate_record_message()
-    record['record']['age'] = 'not an age'
-    singer_stream.add_record_message(record)
+    singer_stream.add_record_message(stream.generate_record_message())
+    singer_stream.add_record_message(stream.generate_record_message())
 
     with pytest.raises(Error):
-        record = stream.generate_record_message()
-        record['record']['adoption'] = [1, 2, 'not a kitty cat']
-
-        singer_stream.add_record_message(record)
+        singer_stream.add_record_message(stream.generate_record_message())

--- a/tests/test_BufferedSingerStream.py
+++ b/tests/test_BufferedSingerStream.py
@@ -16,6 +16,7 @@ def test_add_record_message():
                                          CATS_SCHEMA['schema'],
                                          CATS_SCHEMA['key_properties'])
     assert singer_stream.add_record_message(stream.generate_record_message()) is None
+    assert not singer_stream.peek_invalid_records()
 
 
 def test_add_record_message__invalid_record():
@@ -26,6 +27,9 @@ def test_add_record_message__invalid_record():
     with pytest.raises(Error):
         singer_stream.add_record_message(stream.generate_record_message())
 
+    assert singer_stream.peek_invalid_records()
+    assert singer_stream.count == 0
+
 
 def test_add_record_message__invalid_record__detection_off():
     stream = InvalidCatStream(10)
@@ -35,6 +39,9 @@ def test_add_record_message__invalid_record__detection_off():
                                          invalid_records_detect=False)
 
     singer_stream.add_record_message(stream.generate_record_message())
+
+    assert singer_stream.peek_invalid_records()
+    assert singer_stream.count == 0
 
 
 def test_add_record_message__invalid_record__cross_threshold():
@@ -50,3 +57,6 @@ def test_add_record_message__invalid_record__cross_threshold():
 
     with pytest.raises(Error):
         singer_stream.add_record_message(stream.generate_record_message())
+
+    assert singer_stream.peek_invalid_records()
+    assert singer_stream.count == 0

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -152,6 +152,13 @@ def test_loading__invalid__records__disable():
 
     main(config, input_stream=InvalidCatStream(100))
 
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_columns_sql('cats'))
+            # No columns for a non existent table
+            ## Since all `cat`s records were invalid, we could not persist them, hence, no table created
+            assert not cur.fetchall()
+
 
 def test_loading__invalid__records__threshold():
     config = deepcopy(CONFIG)

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -10,7 +10,7 @@ import pytest
 from target_postgres import main
 from target_postgres import singer_stream
 from target_postgres import postgres
-from fixtures import CatStream, CONFIG, TEST_DB, db_cleanup
+from fixtures import CatStream, InvalidCatStream, CONFIG, TEST_DB, db_cleanup
 
 ## TODO: create and test more fake streams
 ## TODO: test invalid data against JSON Schema
@@ -138,6 +138,27 @@ def test_loading__invalid__configuration__schema():
 
     with pytest.raises(Exception, match=r'.*invalid JSON Schema instance.*'):
         main(CONFIG, input_stream=stream)
+
+
+def test_loading__invalid__records():
+    with pytest.raises(Exception, match=r'.*'):
+        main(CONFIG,
+             input_stream=InvalidCatStream(1))
+
+
+def test_loading__invalid__records__disable():
+    config = deepcopy(CONFIG)
+    config['invalid_records_detect'] = False
+
+    main(config, input_stream=InvalidCatStream(100))
+
+
+def test_loading__invalid__records__threshold():
+    config = deepcopy(CONFIG)
+    config['invalid_records_threshold'] = 10
+
+    with pytest.raises(Exception, match=r'.*.10*'):
+        main(config, input_stream=InvalidCatStream(20))
 
 
 def test_loading__simple(db_cleanup):

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,4 +1,3 @@
-import io
 from copy import deepcopy
 from datetime import datetime
 from unittest.mock import patch
@@ -10,7 +9,7 @@ import pytest
 from target_postgres import main
 from target_postgres import singer_stream
 from target_postgres import postgres
-from fixtures import CatStream, InvalidCatStream, CONFIG, TEST_DB, db_cleanup
+from fixtures import CatStream, CONFIG, db_cleanup, InvalidCatStream, TEST_DB
 
 ## TODO: create and test more fake streams
 ## TODO: test invalid data against JSON Schema


### PR DESCRIPTION
# Motivation
https://github.com/datamill-co/target-postgres/issues/21

## Notes
Attempting to _persist_ a record even though validation failed is not something I worked on in this pr. I initially attempted to provide this level of configuration, however, this introduces a number of...fun...intricacies.

For the time being, records which _do not_ meet validation standards are placed into (effectively) a dead letter queue, whose size is configurable.

An open question is on whether we should be flushing those records in the same manner as the other buffers (as they too can fill up and cause problems for memory etc.). I'm awaiting input from a reviewer as to what to do in this vein.

## Suggested Musical Pairing
https://soundcloud.com/talkingheads/take-me-to-the-river-live?in=talkingheads/sets/stop-making-sense-2