### PR TITLE
Feature/canonicalize column names

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -107,10 +107,9 @@ class PostgresTarget(object):
                 else:
                     records = records_all_versions
 
-                root_table_schema = json_schema.simplify(stream_buffer.schema)
-
-                ## Add singer columns to root table
-                self.add_singer_columns(root_table_schema, stream_buffer.key_properties)
+                root_table_schema = postgres_schema.add_singer_columns(
+                    json_schema.simplify(stream_buffer.schema),
+                    stream_buffer.key_properties)
 
                 subtables = {}
                 key_prop_schemas = {}
@@ -213,36 +212,6 @@ class PostgresTarget(object):
                     version)
                 self.logger.exception(message)
                 raise PostgresError(message, ex)
-
-    def add_singer_columns(self, schema, key_properties):
-        properties = schema['properties']
-
-        if SINGER_RECEIVED_AT not in properties:
-            properties[SINGER_RECEIVED_AT] = {
-                'type': ['null', 'string'],
-                'format': 'date-time'
-            }
-
-        if SINGER_SEQUENCE not in properties:
-            properties[SINGER_SEQUENCE] = {
-                'type': ['null', 'integer']
-            }
-
-        if SINGER_TABLE_VERSION not in properties:
-            properties[SINGER_TABLE_VERSION] = {
-                'type': ['null', 'integer']
-            }
-
-        if SINGER_BATCHED_AT not in properties:
-            properties[SINGER_BATCHED_AT] = {
-                'type': ['null', 'string'],
-                'format': 'date-time'
-            }
-
-        if len(key_properties) == 0:
-            properties[SINGER_PK] = {
-                'type': ['string']
-            }
 
     def process_record_message(self, use_uuid_pk, batched_at, record_message):
         record = record_message['record']

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -10,6 +10,7 @@ import arrow
 from psycopg2 import sql
 
 import target_postgres.json_schema as json_schema
+import target_postgres.postgres_schema as postgres_schema
 from target_postgres.singer_stream import (
     SINGER_RECEIVED_AT,
     SINGER_BATCHED_AT,
@@ -600,8 +601,9 @@ class PostgresTarget(object):
         columns_sql = []
         for prop, item_json_schema in schema['properties'].items():
             sql_type = json_schema.to_sql(item_json_schema)
-            columns_sql.append(sql.SQL('{} {}').format(sql.Identifier(prop),
-                                                       sql.SQL(sql_type)))
+            columns_sql.append(sql.SQL('{} {}').format(
+                sql.Identifier(postgres_schema.canonicalize_column_name(prop)),
+                sql.SQL(sql_type)))
 
         if key_properties:
             comment_sql = sql.SQL('COMMENT ON TABLE {}.{} IS {};').format(
@@ -685,7 +687,7 @@ class PostgresTarget(object):
                     'ADD COLUMN {column_name} {data_type}{default_value};').format(
                     table_schema=sql.Identifier(table_schema),
                     table_name=sql.Identifier(table_name),
-                    column_name=sql.Identifier(column_name),
+                    column_name=sql.Identifier(postgres_schema.canonicalize_column_name(column_name)),
                     data_type=sql.SQL(data_type),
                     default_value=default_value))
 

--- a/target_postgres/postgres_schema.py
+++ b/target_postgres/postgres_schema.py
@@ -1,4 +1,15 @@
+from copy import deepcopy
 import re
+
+from target_postgres.singer_stream import (
+    SINGER_RECEIVED_AT,
+    SINGER_BATCHED_AT,
+    SINGER_SEQUENCE,
+    SINGER_TABLE_VERSION,
+    SINGER_PK,
+    SINGER_SOURCE_PK_PREFIX,
+    SINGER_LEVEL
+)
 
 """
 NAMEDATALEN _defaults_ to 64 in PostgreSQL. The maxmimum length for an identifier is
@@ -43,3 +54,37 @@ def canonicalize_column_name(column_name):
 
     lowered_name = column_name.lower()
     return lowered_name[0] + re.sub(r'[^\w\d_$]', '_', lowered_name[1:])
+
+
+def add_singer_columns(schema, key_properties):
+    ret_schema = deepcopy(schema)
+    properties = ret_schema['properties']
+
+    if SINGER_RECEIVED_AT not in properties:
+        properties[SINGER_RECEIVED_AT] = {
+            'type': ['null', 'string'],
+            'format': 'date-time'
+        }
+
+    if SINGER_SEQUENCE not in properties:
+        properties[SINGER_SEQUENCE] = {
+            'type': ['null', 'integer']
+        }
+
+    if SINGER_TABLE_VERSION not in properties:
+        properties[SINGER_TABLE_VERSION] = {
+            'type': ['null', 'integer']
+        }
+
+    if SINGER_BATCHED_AT not in properties:
+        properties[SINGER_BATCHED_AT] = {
+            'type': ['null', 'string'],
+            'format': 'date-time'
+        }
+
+    if len(key_properties) == 0:
+        properties[SINGER_PK] = {
+            'type': ['string']
+        }
+
+    return ret_schema

--- a/target_postgres/postgres_schema.py
+++ b/target_postgres/postgres_schema.py
@@ -29,12 +29,12 @@ def canonicalize_column_name(column_name):
 
     if not re.match(r'^[a-zA-Z_]', column_name):
         raise SchemaError(
-            'Field {} cannot be canonicalized. Must start with an letter, or underscore'.format(
+            'Field "{}" cannot be canonicalized. Must start with an letter, or underscore'.format(
                 column_name))
 
     if len(column_name) > NAMEDATALEN:
         raise SchemaError(
-            'Field {} cannot be canonicalized. Length {} must be less than or equal to {}'.format(
+            'Field "{}" cannot be canonicalized. Length {} must be less than or equal to {}'.format(
                 column_name,
                 len(column_name),
                 NAMEDATALEN))

--- a/target_postgres/postgres_schema.py
+++ b/target_postgres/postgres_schema.py
@@ -1,0 +1,45 @@
+import re
+
+"""
+NAMEDATALEN _defaults_ to 64 in PostgreSQL. The maxmimum length for an identifier is
+  NAMEDATALEN - 1.
+
+  TODO: Figure out way to `SELECT` value from commands
+"""
+NAMEDATALEN = 63
+
+
+class SchemaError(Exception):
+    """
+    Raise this when there is an error with regards to Postgres Schemas
+    """
+
+
+def canonicalize_column_name(column_name):
+    """
+    Given a column name, canonicalize name such that it can be
+    used as a Postgres column identifier.
+
+    For details or a full list of restrictions, see: https://www.postgresql.org/docs/9.4/sql-syntax-lexical.html
+
+    TODO: allow for non latin characters
+    :param column_name: String
+    :return: String
+    """
+
+    if not re.match(r'^[a-zA-Z_]', column_name):
+        raise SchemaError(
+            'Field {} cannot be canonicalized. Must start with an letter, or underscore'.format(
+                column_name))
+
+    if len(column_name) > NAMEDATALEN:
+        raise SchemaError(
+            'Field {} cannot be canonicalized. Length {} must be less than or equal to {}'.format(
+                column_name,
+                len(column_name),
+                NAMEDATALEN))
+
+    ## Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($)
+
+    lowered_name = column_name.lower()
+    return lowered_name[0] + re.sub(r'[^\w\d_$]', '_', lowered_name[1:])

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -1,0 +1,36 @@
+import re
+
+import pytest
+
+from target_postgres import postgres_schema
+
+
+def test_canonicalize_column_name():
+    for normal_name in ['test', 'test123', 'test_12_3']:
+        assert normal_name == postgres_schema.canonicalize_column_name(normal_name)
+
+
+def test_canonicalize_column_name__error__empty():
+    with pytest.raises(postgres_schema.SchemaError):
+        postgres_schema.canonicalize_column_name('')
+
+
+def test_canonicalize_column_name__error__non_alpha_underscore():
+    with pytest.raises(postgres_schema.SchemaError):
+        postgres_schema.canonicalize_column_name('123abcd')
+
+
+def test_canonicalize_column_name__error__length():
+    with pytest.raises(postgres_schema.SchemaError):
+        postgres_schema.canonicalize_column_name('a' * (postgres_schema.NAMEDATALEN + 1))
+
+    with pytest.raises(postgres_schema.SchemaError):
+        postgres_schema.canonicalize_column_name('Z' * (postgres_schema.NAMEDATALEN + 10))
+
+
+def test_canonicalize_column_name__capitalization():
+    assert re.match(r'[a-z]+', postgres_schema.canonicalize_column_name('ABCDHIJK'))
+
+
+def test_canonicalize_column_name__replacement():
+    assert '_rep$lac___ement_test' == postgres_schema.canonicalize_column_name('_REP$lac!!!EMENT-test')


### PR DESCRIPTION
# Motivation
https://github.com/datamill-co/target-postgres/issues/18

This is the first pr in a series. Proper handling of PSQL names involves non-latin characters, unicode, and general madness. As such, I've tried to split this work up into the following passes:

- detect invalid names (ASCII only)
- normalize names (leverage PSQL comments to store information about schema etc.)
- quotes support (?)
- unicode support (?)

## Suggested Musical Pairing
https://soundcloud.com/starfucker_usa/golden-light-1