### PR TITLE
Refactor/sql schema

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -10,7 +10,7 @@ import arrow
 from psycopg2 import sql
 
 import target_postgres.json_schema as json_schema
-from target_postgres.sql_schema import SQLSchema
+from target_postgres.sql_schema import SQLSchema, NESTED_SEPARATOR
 from target_postgres.singer_stream import (
     SINGER_RECEIVED_AT,
     SINGER_BATCHED_AT,
@@ -34,7 +34,6 @@ class TransformStream(object):
         return self.fun()
 
 class PostgresTarget(object):
-    NESTED_SEPARATOR = '__'
 
     def __init__(self, connection, logger, *args, postgres_schema='public', **kwargs):
         self.conn = connection
@@ -97,7 +96,7 @@ class PostgresTarget(object):
 
                 if current_table_version is not None and \
                    target_table_version > current_table_version:
-                    root_table_name = stream_buffer.stream + self.NESTED_SEPARATOR + str(target_table_version)
+                    root_table_name = stream_buffer.stream + NESTED_SEPARATOR + str(target_table_version)
                 else:
                     root_table_name = stream_buffer.stream
 
@@ -174,7 +173,7 @@ class PostgresTarget(object):
                         stream_buffer.stream,
                         version))
                 else:
-                    versioned_root_table = stream_buffer.stream + self.NESTED_SEPARATOR + str(version)
+                    versioned_root_table = stream_buffer.stream + NESTED_SEPARATOR + str(version)
 
                     cur.execute(
                         sql.SQL('''
@@ -194,7 +193,7 @@ class PostgresTarget(object):
                             COMMIT;''').format(
                                 table_schema=sql.Identifier(self.postgres_schema),
                                 stream_table_old=sql.Identifier(table_name +
-                                                                self.NESTED_SEPARATOR +
+                                                                NESTED_SEPARATOR +
                                                                 'old'),
                                 stream_table=sql.Identifier(table_name),
                                 version_table=sql.Identifier(versioned_table_name)))
@@ -205,36 +204,6 @@ class PostgresTarget(object):
                     version)
                 self.logger.exception(message)
                 raise PostgresError(message, ex)
-
-    def add_singer_columns(self, schema, key_properties):
-        properties = schema['properties']
-
-        if SINGER_RECEIVED_AT not in properties:
-            properties[SINGER_RECEIVED_AT] = {
-                'type': ['null', 'string'],
-                'format': 'date-time'
-            }
-
-        if SINGER_SEQUENCE not in properties:
-            properties[SINGER_SEQUENCE] = {
-                'type': ['null', 'integer']
-            }
-
-        if SINGER_TABLE_VERSION not in properties:
-            properties[SINGER_TABLE_VERSION] = {
-                'type': ['null', 'integer']
-            }
-
-        if SINGER_BATCHED_AT not in properties:
-            properties[SINGER_BATCHED_AT] = {
-                'type': ['null', 'string'],
-                'format': 'date-time'
-            }
-
-        if len(key_properties) == 0:
-            properties[SINGER_PK] = {
-                'type': ['string']
-            }
 
     def process_record_message(self, use_uuid_pk, batched_at, record_message):
         record = record_message['record']
@@ -257,91 +226,6 @@ class PostgresTarget(object):
 
         return record
 
-    def denest_schema_helper(self,
-                             table_name,
-                             table_json_schema,
-                             not_null,
-                             top_level_schema,
-                             current_path,
-                             key_prop_schemas,
-                             subtables,
-                             level):
-        for prop, item_json_schema in table_json_schema['properties'].items():
-            next_path = current_path + self.NESTED_SEPARATOR + prop
-            if json_schema.is_object(item_json_schema):
-                self.denest_schema_helper(table_name,
-                                          item_json_schema,
-                                          not_null,
-                                          top_level_schema,
-                                          next_path,
-                                          key_prop_schemas,
-                                          subtables,
-                                          level)
-            elif json_schema.is_iterable(item_json_schema):
-                self.create_subtable(table_name + self.NESTED_SEPARATOR + prop,
-                                     item_json_schema,
-                                     key_prop_schemas,
-                                     subtables,
-                                     level + 1)
-            else:
-                if not_null and json_schema.is_nullable(item_json_schema):
-                    item_json_schema['type'].remove('null')
-                elif not json_schema.is_nullable(item_json_schema):
-                    item_json_schema['type'].append('null')
-                top_level_schema[next_path] = item_json_schema
-
-    def create_subtable(self, table_name, table_json_schema, key_prop_schemas, subtables, level):
-        if json_schema.is_object(table_json_schema['items']):
-            new_properties = table_json_schema['items']['properties']
-        else:
-            new_properties = {'value': table_json_schema['items']}
-
-        for pk, item_json_schema in key_prop_schemas.items():
-            new_properties[SINGER_SOURCE_PK_PREFIX + pk] = item_json_schema
-
-        new_properties[SINGER_SEQUENCE] = {
-            'type': ['null', 'integer']
-        }
-
-        for i in range(0, level + 1):
-            new_properties[SINGER_LEVEL.format(i)] = {
-                'type': ['integer']
-            }
-
-        new_schema = {'type': ['object'], 'properties': new_properties}
-
-        self.denest_schema(table_name, new_schema, key_prop_schemas, subtables, level=level)
-
-        subtables[table_name] = new_schema
-
-    def denest_schema(self, table_name, table_json_schema, key_prop_schemas, subtables, current_path=None, level=-1):
-        new_properties = {}
-        for prop, item_json_schema in table_json_schema['properties'].items():
-            if current_path:
-                next_path = current_path + self.NESTED_SEPARATOR + prop
-            else:
-                next_path = prop
-
-            if json_schema.is_object(item_json_schema):
-                not_null = 'null' not in item_json_schema['type']
-                self.denest_schema_helper(table_name + self.NESTED_SEPARATOR + next_path,
-                                          item_json_schema,
-                                          not_null,
-                                          new_properties,
-                                          next_path,
-                                          key_prop_schemas,
-                                          subtables,
-                                          level)
-            elif json_schema.is_iterable(item_json_schema):
-                self.create_subtable(table_name + self.NESTED_SEPARATOR + next_path,
-                                     item_json_schema,
-                                     key_prop_schemas,
-                                     subtables,
-                                     level + 1)
-            else:
-                new_properties[prop] = item_json_schema
-        table_json_schema['properties'] = new_properties
-
     def denest_subrecord(self,
                          table_name,
                          current_path,
@@ -352,11 +236,11 @@ class PostgresTarget(object):
                          pk_fks,
                          level):
         for prop, value in record.items():
-            next_path = current_path + self.NESTED_SEPARATOR + prop
+            next_path = current_path + NESTED_SEPARATOR + prop
             if isinstance(value, dict):
                 self.denest_subrecord(table_name, next_path, parent_record, value, pk_fks, level)
             elif isinstance(value, list):
-                self.denest_records(table_name + self.NESTED_SEPARATOR + next_path,
+                self.denest_records(table_name + NESTED_SEPARATOR + next_path,
                                     value,
                                     records_map,
                                     key_properties,
@@ -369,7 +253,7 @@ class PostgresTarget(object):
         denested_record = {}
         for prop, value in record.items():
             if current_path:
-                next_path = current_path + self.NESTED_SEPARATOR + prop
+                next_path = current_path + NESTED_SEPARATOR + prop
             else:
                 next_path = prop
 
@@ -383,7 +267,7 @@ class PostgresTarget(object):
                                       pk_fks,
                                       level)
             elif isinstance(value, list):
-                self.denest_records(table_name + self.NESTED_SEPARATOR + next_path,
+                self.denest_records(table_name + NESTED_SEPARATOR + next_path,
                                     value,
                                     records_map,
                                     key_properties,
@@ -609,7 +493,7 @@ class PostgresTarget(object):
                                                  comment_sql))
 
     def get_temp_table_name(self, stream_name):
-        return stream_name + self.NESTED_SEPARATOR + str(uuid.uuid4()).replace('-', '')
+        return stream_name + NESTED_SEPARATOR + str(uuid.uuid4()).replace('-', '')
 
     def get_table_metadata(self, cur, table_schema, table_name):
         cur.execute(

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -107,7 +107,7 @@ class PostgresTarget(object):
                     records = records_all_versions
 
                 sql_schema = SQLSchema(root_table_name, stream_buffer)
-                root_table_schema = sql_schema.get_tables()[0][1]
+                root_table_schema = sql_schema.get_tables()[0].get_schema()
 
                 root_temp_table_name = self.upsert_table_schema(cur,
                                                                 root_table_name,
@@ -116,15 +116,15 @@ class PostgresTarget(object):
                                                                 target_table_version)
 
                 nested_upsert_tables = []
-                for table_name, subtable_json_schema in sql_schema.get_tables()[1:]:
+                for table_schema in sql_schema.get_tables()[1:]:
                     temp_table_name = self.upsert_table_schema(cur,
-                                                               table_name,
-                                                               subtable_json_schema,
+                                                               table_schema.get_name(),
+                                                               table_schema.get_schema(),
                                                                None,
                                                                None)
                     nested_upsert_tables.append({
-                        'table_name': table_name,
-                        'json_schema': subtable_json_schema,
+                        'table_name': table_schema.get_name(),
+                        'json_schema': table_schema.get_schema(),
                         'temp_table_name': temp_table_name
                     })
 

--- a/target_postgres/sql_schema.py
+++ b/target_postgres/sql_schema.py
@@ -1,0 +1,160 @@
+import target_postgres.json_schema as json_schema
+from target_postgres.singer_stream import (
+    SINGER_RECEIVED_AT,
+    SINGER_BATCHED_AT,
+    SINGER_SEQUENCE,
+    SINGER_TABLE_VERSION,
+    SINGER_PK,
+    SINGER_SOURCE_PK_PREFIX,
+    SINGER_LEVEL
+)
+
+NESTED_SEPARATOR = '__'
+
+
+def _denest_schema(table_name, table_json_schema, key_prop_schemas, subtables, current_path=None, level=-1):
+    new_properties = {}
+    for prop, item_json_schema in table_json_schema['properties'].items():
+        if current_path:
+            next_path = current_path + NESTED_SEPARATOR + prop
+        else:
+            next_path = prop
+
+        if json_schema.is_object(item_json_schema):
+            not_null = 'null' not in item_json_schema['type']
+            _denest_schema_helper(table_name + NESTED_SEPARATOR + next_path,
+                                  item_json_schema,
+                                  not_null,
+                                  new_properties,
+                                  next_path,
+                                  key_prop_schemas,
+                                  subtables,
+                                  level)
+        elif json_schema.is_iterable(item_json_schema):
+            _create_subtable(table_name + NESTED_SEPARATOR + next_path,
+                             item_json_schema,
+                             key_prop_schemas,
+                             subtables,
+                             level + 1)
+        else:
+            new_properties[prop] = item_json_schema
+    table_json_schema['properties'] = new_properties
+
+
+def _create_subtable(table_name, table_json_schema, key_prop_schemas, subtables, level):
+    if json_schema.is_object(table_json_schema['items']):
+        new_properties = table_json_schema['items']['properties']
+    else:
+        new_properties = {'value': table_json_schema['items']}
+
+    for pk, item_json_schema in key_prop_schemas.items():
+        new_properties[SINGER_SOURCE_PK_PREFIX + pk] = item_json_schema
+
+    new_properties[SINGER_SEQUENCE] = {
+        'type': ['null', 'integer']
+    }
+
+    for i in range(0, level + 1):
+        new_properties[SINGER_LEVEL.format(i)] = {
+            'type': ['integer']
+        }
+
+    new_schema = {'type': ['object'], 'properties': new_properties}
+
+    _denest_schema(table_name, new_schema, key_prop_schemas, subtables, level=level)
+
+    subtables[table_name] = new_schema
+
+
+def _denest_schema_helper(
+        table_name,
+        table_json_schema,
+        not_null,
+        top_level_schema,
+        current_path,
+        key_prop_schemas,
+        subtables,
+        level):
+    for prop, item_json_schema in table_json_schema['properties'].items():
+        next_path = current_path + NESTED_SEPARATOR + prop
+        if json_schema.is_object(item_json_schema):
+            _denest_schema_helper(table_name,
+                                  item_json_schema,
+                                  not_null,
+                                  top_level_schema,
+                                  next_path,
+                                  key_prop_schemas,
+                                  subtables,
+                                  level)
+        elif json_schema.is_iterable(item_json_schema):
+            _create_subtable(table_name + NESTED_SEPARATOR + prop,
+                             item_json_schema,
+                             key_prop_schemas,
+                             subtables,
+                             level + 1)
+        else:
+            if not_null and json_schema.is_nullable(item_json_schema):
+                item_json_schema['type'].remove('null')
+            elif not json_schema.is_nullable(item_json_schema):
+                item_json_schema['type'].append('null')
+            top_level_schema[next_path] = item_json_schema
+
+
+def _add_singer_columns(schema, key_properties):
+    properties = schema['properties']
+
+    if SINGER_RECEIVED_AT not in properties:
+        properties[SINGER_RECEIVED_AT] = {
+            'type': ['null', 'string'],
+            'format': 'date-time'
+        }
+
+    if SINGER_SEQUENCE not in properties:
+        properties[SINGER_SEQUENCE] = {
+            'type': ['null', 'integer']
+        }
+
+    if SINGER_TABLE_VERSION not in properties:
+        properties[SINGER_TABLE_VERSION] = {
+            'type': ['null', 'integer']
+        }
+
+    if SINGER_BATCHED_AT not in properties:
+        properties[SINGER_BATCHED_AT] = {
+            'type': ['null', 'string'],
+            'format': 'date-time'
+        }
+
+    if len(key_properties) == 0:
+        properties[SINGER_PK] = {
+            'type': ['string']
+        }
+
+
+class SQLSchema(object):
+    def __init__(self, table_name, stream_buffer):
+        temp_json_schema = json_schema.simplify(stream_buffer.schema)
+        _add_singer_columns(temp_json_schema, stream_buffer.key_properties)
+        key_prop_schemas = {}
+        for key in stream_buffer.key_properties:
+            key_prop_schemas[key] = temp_json_schema['properties'][key]
+
+        sub_tables_dict = {}
+        _denest_schema(table_name,
+                       temp_json_schema,
+                       key_prop_schemas,
+                       sub_tables_dict)
+        self.tables = [(table_name, temp_json_schema)]
+        for name, schema in sub_tables_dict.items():
+            self.tables.append((name, schema))
+
+    def get_tables(self):
+        """
+        Return the table schemas for the given SQLSchema. The
+        root table's schema will be first, with all other sub table
+        schemas following.
+
+        :return: [root_table_schema, nested_table_schema_0, ...]
+        """
+
+        return self.tables


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/pull/28
https://github.com/datamill-co/target-postgres/issues/4

In light of a recent pr, it seems like we're butting up against the essential core of generic-SQL, Postgres, and Redshift sections of this codebase. Due to this, this PR aims to provide some groundwork to be able to abstract out the core SQL operations, vs the more Postgres specific.

## Notes

This PR introduces no _new_ functionality.

To reduce scope, the only classes/objects this PR creates are related to Schema.

## Proposed Next Steps

The proposed next steps along this trajectory are:
- pull table version info and logic into `SQLSchema`
- expose functions and move functionality for schema collision/upsert/remote-fetch into `SQLSchema`/`TableSchema`
- introduce table/column name canonicalization and error detection
- introduce a `SQLPersistence` (name pending) class which moves base persistence functionality (like de-nesting records etc.) into a new class

## Suggested Musical Pairing
https://soundcloud.com/pondling/man-it-feels-like-space-again