### PR TITLE
Feature/type collision

### DIFF
--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -205,6 +205,18 @@ def test_loading__simple(db_cleanup):
 
         assert_records(conn, stream.records, 'cats', 'id')
 
+
+def test_loading__column_type_change(db_cleanup):
+    main(CONFIG, input_stream=CatStream(100))
+
+    with pytest.raises(postgres.PostgresError, match=r'Column type change detected.*'):
+        stream = CatStream(20)
+        stream.schema = deepcopy(stream.schema)
+        stream.schema['schema']['properties']['name']['type'].append('null')
+
+        main(CONFIG, input_stream=stream)
+
+
 def test_upsert(db_cleanup):
     stream = CatStream(100)
     main(CONFIG, input_stream=stream)


### PR DESCRIPTION
# Motivation
https://github.com/datamill-co/target-postgres/issues/12

Simple pr to start detecting column type changes.

## Notes
Future work on this will follow the plan laid out in #12. Presently, we need a hook/location to be able to alert about the type change. Following that we can `add_column('name__type')` and `drop_column` etc.

## Suggested Musical Pairing
https://soundcloud.com/phoenix/lisztomania