### PR TITLE
Fix/null default

### DIFF
--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -206,7 +206,7 @@ def validation_errors(schema):
     return errors
 
 
-def from_sql(sql_type, nullable):
+def from_sql(sql_type, nullable, default):
     _format = None
     if sql_type == 'timestamp with time zone':
         json_type = 'string'
@@ -229,6 +229,9 @@ def from_sql(sql_type, nullable):
     ret_json_schema = {'type': json_type}
     if _format:
         ret_json_schema['format'] = _format
+
+    if default:
+        ret_json_schema['default'] = default
 
     return ret_json_schema
 

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -103,10 +103,7 @@ def is_nullable(schema):
 def _helper_simplify(root_schema, child_schema):
     ret_schema = {}
 
-    if not child_schema:
-        pass
-
-    elif is_ref(child_schema):
+    if is_ref(child_schema):
         try:
             ret_schema = _helper_simplify(root_schema, get_ref(root_schema, child_schema['$ref']))
         except RecursionError:

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -227,7 +227,7 @@ def from_sql(sql_type, nullable, default):
     if _format:
         ret_json_schema['format'] = _format
 
-    if default:
+    if default is not None:
         ret_json_schema['default'] = default
 
     return ret_json_schema

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -552,12 +552,20 @@ class PostgresTarget(object):
         datetime_fields = [k for k,v in target_table_json_schema['properties'].items()
                            if v.get('format') == 'date-time']
 
+        default_fields = [k for k,v in target_table_json_schema['properties'].items()
+                          if v.get('default')]
+
         rows = iter(records)
 
         def transform():
             try:
                 row = next(rows)
                 with io.StringIO() as out:
+                    ## Serialize fields which are not present but have default values set
+                    for prop in default_fields:
+                        if not prop in row:
+                            row[prop] = target_table_json_schema['properties'][prop]['default']
+
                     ## Serialize datetime to postgres compatible format
                     for prop in datetime_fields:
                         if prop in row:

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -674,7 +674,7 @@ class PostgresTarget(object):
 
     def get_schema(self, cur, table_schema, table_name):
         cur.execute(
-            sql.SQL('SELECT column_name, data_type, is_nullable FROM information_schema.columns ') +
+            sql.SQL('SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns ') +
             sql.SQL('WHERE table_schema = {} and table_name = {};').format(
                 sql.Literal(table_schema), sql.Literal(table_name)))
         columns = cur.fetchall()
@@ -684,7 +684,7 @@ class PostgresTarget(object):
 
         properties = {}
         for column in columns:
-            properties[column[0]] = json_schema.from_sql(column[1], column[2] == 'YES')
+            properties[column[0]] = json_schema.from_sql(column[1], column[2] == 'YES', column[3])
 
         schema = {'properties': properties}
 

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -553,7 +553,7 @@ class PostgresTarget(object):
                            if v.get('format') == 'date-time']
 
         default_fields = [k for k,v in target_table_json_schema['properties'].items()
-                          if v.get('default')]
+                          if v.get('default') is not None]
 
         rows = iter(records)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -36,6 +36,10 @@ CATS_SCHEMA = {
             'name': {
                 'type': ['string']
             },
+            'paw_size': {
+                'type': ['integer'],
+                'default': 314159
+            },
             'pattern': {
                 'type': ['null', 'string']
             },

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,6 +40,10 @@ CATS_SCHEMA = {
                 'type': ['integer'],
                 'default': 314159
             },
+            'flea_check_complete': {
+                'type': ['boolean'],
+                'default': False
+            },
             'pattern': {
                 'type': ['null', 'string']
             },

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -12,8 +12,8 @@ def test_is_object():
     assert json_schema.is_object({})
 
 
-def test_simplify__empty():
-    assert json_schema.simplify({}) == {}
+def test_simplify__empty_becomes_object():
+    assert json_schema.simplify({}) == {'properties': {}, 'type': ['object']}
 
 
 def test_simplify__types_into_arrays():

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -69,6 +69,10 @@ def test_simplify__complex():
                 'name': {
                     'type': ['string']
                 },
+                'paw_size': {
+                    'type': ['integer'],
+                    'default': 314159
+                },
                 'pattern': {
                     'type': ['null', 'string']
                 },

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -73,6 +73,10 @@ def test_simplify__complex():
                     'type': ['integer'],
                     'default': 314159
                 },
+                'flea_check_complete': {
+                    'type': ['boolean'],
+                    'default': False
+                },
                 'pattern': {
                     'type': ['null', 'string']
                 },

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -187,6 +187,7 @@ def test_loading__simple(db_cleanup):
                 ('id', 'bigint', 'NO'),
                 ('name', 'text', 'NO'),
                 ('paw_size', 'bigint', 'NO'),
+                ('flea_check_complete', 'boolean', 'NO'),
                 ('pattern', 'text', 'YES')
             }
 

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -186,6 +186,7 @@ def test_loading__simple(db_cleanup):
                 ('age', 'bigint', 'YES'),
                 ('id', 'bigint', 'NO'),
                 ('name', 'text', 'NO'),
+                ('paw_size', 'bigint', 'NO'),
                 ('pattern', 'text', 'YES')
             }
 


### PR DESCRIPTION
# Motivation
JSONSchema defines a `default` field to hint to validators, etc., that the given property does not need to meet it's `not null` constraint, and that if this failure case is reached, to simply use the default instead.

Presently, we do not handle a couple things:
- create a table with defaults
- our persist method doesn't play nice with default values in general
  - even if the column has a default set in SQL, it will not utilize that when the copy places `null`
  - this becomes especially tricky when you have mixed null/not-null values in a csv column...

## Notes
If there is a simple solution to get the CSV copy to play nicely, then I think we should use that.

This brute force approach works though.

## Suggested Musical Pairing
https://soundcloud.com/ugly-casanova/barnacles