### PR TITLE
Housekeeping/logger warn is deprecated

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    error
+    ignore::UserWarning
+    ignore:.*Using or importing the ABCs from:DeprecationWarning

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -38,7 +38,7 @@ def flush_streams(streams, target, force=False):
 def report_invalid_records(streams):
     for stream_buffer in streams.values():
         if stream_buffer.peek_invalid_records():
-            LOGGER.warn("Invalid records detected for stream {}: {}".format(
+            LOGGER.warning("Invalid records detected for stream {}: {}".format(
                 stream_buffer.stream,
                 stream_buffer.peek_invalid_records()
             ))
@@ -108,7 +108,7 @@ def line_handler(streams, target, invalid_records_detect, invalid_records_thresh
         target.write_batch(stream_buffer)
         target.activate_version(stream_buffer, line_data['version'])
     elif line_data['type'] == 'STATE':
-        LOGGER.warn('`STATE` Singer message type not supported')
+        LOGGER.warning('`STATE` Singer message type not supported')
     else:
         raise TargetError('Unknown message type {} in message {}'.format(
             line_data['type'],

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -90,12 +90,12 @@ class PostgresTarget(object):
                     target_table_version = None
 
                 if current_table_version is not None and \
-                   min(versions) < current_table_version:
-                    self.logger.warn('{} - Records from an earlier table vesion detected.'
-                                     .format(stream_buffer.stream))
+                        min(versions) < current_table_version:
+                    self.logger.warning('{} - Records from an earlier table vesion detected.'
+                                        .format(stream_buffer.stream))
                 if len(versions) > 1:
-                    self.logger.warn('{} - Multiple table versions in stream, only using the latest.'
-                                     .format(stream_buffer.stream))
+                    self.logger.warning('{} - Multiple table versions in stream, only using the latest.'
+                                        .format(stream_buffer.stream))
 
                 if current_table_version is not None and \
                    target_table_version > current_table_version:
@@ -180,7 +180,7 @@ class PostgresTarget(object):
                     self.logger.error('{} - Table for stream does not exist'.format(
                         stream_buffer.stream))
                 elif table_metadata.get('version') == version:
-                    self.logger.warn('{} - Table version {} already active'.format(
+                    self.logger.warning('{} - Table version {} already active'.format(
                         stream_buffer.stream,
                         version))
                 else:
@@ -577,7 +577,7 @@ class PostgresTarget(object):
 
                         ## Serialize NULL default value
                         if row.get(prop, False) == RESERVED_NULL_DEFAULT:
-                            self.logger.warn(
+                            self.logger.warning(
                                 'Reserved {} value found at: {}.{}.{}. Value will be turned into literal null'.format(
                                     RESERVED_NULL_DEFAULT,
                                     self.postgres_schema,


### PR DESCRIPTION
# Motivation
https://github.com/datamill-co/target-postgres/issues/33

## Notes
This looks much better in the testing output!

```
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.7.1, pytest-3.9.3, py-1.7.0, pluggy-0.8.0
rootdir: /code, inifile: pytest.ini
collected 35 items                                                                                                                                                                                         

tests/test_BufferedSingerStream.py .....                                                                                                                                                             [ 14%]
tests/test_json_schema.py ............                                                                                                                                                               [ 48%]
tests/test_postgres.py ..................                                                                                                                                                            [100%]

======================================================================================== 35 passed in 6.73 seconds =========================================================================================
```

Namely:

> ====== 35 passed in 6.73 seconds ========

Usually that was littered with various warnings and whatnot.

## Suggested Musical Pairing
https://soundcloud.com/ugly-casanova/barnacles