### PR TITLE
Housekeeping/development improvements docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.7.1-stretch
 
+RUN echo 'alias pytest="python setup.py pytest"' >> ~/.bashrc
+
 ADD ./ /code
 WORKDIR /code
+RUN python setup.py develop
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ docker logs -tf target-postgres_target-postgres_1 # You container names might 
 As soon as you see `INFO: Dev environment ready.` you can shell into the container and start running test commands:
 
 ```sh
-$ docker exec -it target-postgres_target-postgres_1 sh # Your container names might differ
+$ docker exec -it target-postgres_target-postgres_1 bash # Your container names might differ
 ```
 
 See the [PyTest](#pytest) commands below!
@@ -155,6 +155,12 @@ To run tests, try:
 
 ```sh
 $ python setup.py pytest
+```
+
+If you've `bash` shelled into the Docker Compose container ([see above](#docker)), you should be able to simply use:
+
+```sh
+$ pytest
 ```
 
 ## Sponsorship

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 
-python setup.py develop
-
 echo -e "\n\nINFO: Dev environment ready."
 tail -f /dev/null


### PR DESCRIPTION
# Motivation
A portion of my time is spent typing out `python setup.py pytest`. Additionally, whenever docker has to restart, or I do anything which fumbles the eggs etc., I have to re-download the world.

This pr aims to do three simple things:
- suggest shelling into the container using `bash` instead of `sh`
  - our container supports this, and it makes life easier (history! autocomplete! hurrah!)
- setup alias for the `pytest` command
  - due to the above as well, you get autocomplete for it, yahtzee!
- cache python files based on whether or not `setup.py` has changed in the Docker build step
  - this means that the container _itself_ actually caches these values

## Testing
```sh
$ docker-compose up -d --build
...
Best match: pytz 2018.7
Processing pytz-2018.7-py2.py3-none-any.whl
Installing pytz-2018.7-py2.py3-none-any.whl to /usr/local/lib/python3.7/site-packages
Adding pytz 2018.7 to easy-install.pth file

Installed /usr/local/lib/python3.7/site-packages/pytz-2018.7-py3.7.egg
Finished processing dependencies for target-postgres==0.0.1
Removing intermediate container 5ffdbc7c0a65
 ---> f82310941dcb
Step 6/6 : ENTRYPOINT ["./docker-entrypoint.sh"]
 ---> Running in e9601b0b87d9
Removing intermediate container e9601b0b87d9
 ---> 98d30d87c548
Successfully built 98d30d87c548
Successfully tagged target-postgres_target-postgres:latest
Creating target-postgres_target-postgres_1 ... done
Creating target-postgres_db_1              ... done

$ bash -c "clear && docker exec -it target-postgres_target-postgres_1 bash"

root@be07c3b690d3:/code# pytest
...
============== 35 passed, 26 warnings in 8.84 seconds ==================
```

## Suggested Musical Pairing
Coffee shop sounds
