### PR TITLE
Housekeeping/pylint  object useless

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import arrow
 from psycopg2 import sql
 
-import target_postgres.json_schema as json_schema
+from target_postgres import json_schema
 from target_postgres.singer_stream import (
     SINGER_RECEIVED_AT,
     SINGER_BATCHED_AT,
@@ -28,14 +28,14 @@ class PostgresError(Exception):
     Raise this when there is an error with regards to Postgres streaming
     """
 
-class TransformStream(object):
+class TransformStream():
     def __init__(self, fun):
         self.fun = fun
 
     def read(self, *args, **kwargs):
         return self.fun()
 
-class PostgresTarget(object):
+class PostgresTarget():
     NESTED_SEPARATOR = '__'
 
     def __init__(self, connection, logger, *args, postgres_schema='public', **kwargs):

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -19,7 +19,7 @@ SINGER_SOURCE_PK_PREFIX = '_sdc_source_key_'
 SINGER_LEVEL = '_sdc_level_{}_id'
 
 
-class BufferedSingerStream(object):
+class BufferedSingerStream():
     def __init__(self,
                  stream,
                  schema,


### PR DESCRIPTION
# Motivation

For kicks, I downloaded `pylint` to see what state our repo is in. There are some glaring trickier issues, but one of the low hanging fruits are a couple of problems which `pylint` tags (loosely) as `.*useless.*`.

I tidied those few things up.

## Testing
### Before

```sh
root@be07c3b690d3:/code# pylint target_postgres/ | grep useless
target_postgres/postgres.py:12:0: C0414: Import alias does not rename original package (useless-import-alias)
target_postgres/postgres.py:31:0: R0205: Class 'TransformStream' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
target_postgres/postgres.py:38:0: R0205: Class 'PostgresTarget' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
target_postgres/singer_stream.py:22:0: R0205: Class 'BufferedSingerStream' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
```

### After

```sh
root@be07c3b690d3:/code# pylint target_postgres/ | grep useless
```

## Suggested Musical Pairing
Keyboard typing