### PR TITLE
Feature/column type splitting

### DIFF
--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -279,3 +279,32 @@ def to_sql(schema):
         sql_type += ' NOT NULL'
 
     return sql_type
+
+
+_shorthand_mapping = {
+    'null': '',
+    'string': 's',
+    'number': 'f',
+    'integer': 'i',
+    'boolean': 'b',
+}
+
+
+def _type_shorthand(type_s):
+    if isinstance(type_s, list):
+        shorthand = ''
+        for type in sorted(type_s):
+            shorthand += _type_shorthand(type)
+        return shorthand
+
+    if not type_s in _shorthand_mapping:
+        raise JSONSchemaError('Shorthand not available for type {}. Expected one of {}'.format(
+            type_s,
+            list(_shorthand_mapping.keys())
+        ))
+
+    return _shorthand_mapping[type_s]
+
+
+def sql_shorthand(schema):
+    return _type_shorthand(get_type(schema))

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -429,28 +429,27 @@ class PostgresTarget():
         existing_table_schema = self.get_schema(cur, self.postgres_schema, table_name)
 
         if existing_table_schema is not None:
-            schema = self.merge_put_schemas(cur,
-                                            self.postgres_schema,
-                                            table_name,
-                                            existing_table_schema,
-                                            schema)
-            target_table_name = self.get_temp_table_name(table_name)
+            self.merge_put_schemas(cur,
+                                   self.postgres_schema,
+                                   table_name,
+                                   existing_table_schema,
+                                   schema)
         else:
-            schema = schema
             self.create_table(cur,
-                               self.postgres_schema,
-                               table_name,
-                               schema,
-                               key_properties,
-                               table_version)
-            target_table_name = self.get_temp_table_name(table_name)
+                              self.postgres_schema,
+                              table_name,
+                              schema,
+                              key_properties,
+                              table_version)
+
+        target_table_name = self.get_temp_table_name(table_name)
 
         self.create_table(cur,
-                           self.postgres_schema,
-                           target_table_name,
-                           schema,
-                           key_properties,
-                           table_version)
+                          self.postgres_schema,
+                          target_table_name,
+                          self.get_schema(cur, self.postgres_schema, table_name).get('schema'),
+                          key_properties,
+                          table_version)
 
         return target_table_name
 
@@ -820,5 +819,3 @@ class PostgresTarget():
                         name,
                         self.mapping_name(name, schema)
                     ))
-
-        return existing_schema['schema']

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -36,7 +36,7 @@ class TransformStream():
         return self.fun()
 
 class PostgresTarget():
-    NESTED_SEPARATOR = '__'
+    SEPARATOR = '__'
 
     def __init__(self, connection, logger, *args, postgres_schema='public', **kwargs):
         self.conn = connection
@@ -99,7 +99,7 @@ class PostgresTarget():
 
                 if current_table_version is not None and \
                    target_table_version > current_table_version:
-                    root_table_name = stream_buffer.stream + self.NESTED_SEPARATOR + str(target_table_version)
+                    root_table_name = stream_buffer.stream + self.SEPARATOR + str(target_table_version)
                 else:
                     root_table_name = stream_buffer.stream
 
@@ -184,7 +184,7 @@ class PostgresTarget():
                         stream_buffer.stream,
                         version))
                 else:
-                    versioned_root_table = stream_buffer.stream + self.NESTED_SEPARATOR + str(version)
+                    versioned_root_table = stream_buffer.stream + self.SEPARATOR + str(version)
 
                     cur.execute(
                         sql.SQL('''
@@ -204,7 +204,7 @@ class PostgresTarget():
                             COMMIT;''').format(
                                 table_schema=sql.Identifier(self.postgres_schema),
                                 stream_table_old=sql.Identifier(table_name +
-                                                                self.NESTED_SEPARATOR +
+                                                                self.SEPARATOR +
                                                                 'old'),
                                 stream_table=sql.Identifier(table_name),
                                 version_table=sql.Identifier(versioned_table_name)))
@@ -277,7 +277,7 @@ class PostgresTarget():
                              subtables,
                              level):
         for prop, item_json_schema in table_json_schema['properties'].items():
-            next_path = current_path + self.NESTED_SEPARATOR + prop
+            next_path = current_path + self.SEPARATOR + prop
             if json_schema.is_object(item_json_schema):
                 self.denest_schema_helper(table_name,
                                           item_json_schema,
@@ -288,7 +288,7 @@ class PostgresTarget():
                                           subtables,
                                           level)
             elif json_schema.is_iterable(item_json_schema):
-                self.create_subtable(table_name + self.NESTED_SEPARATOR + prop,
+                self.create_subtable(table_name + self.SEPARATOR + prop,
                                      item_json_schema,
                                      key_prop_schemas,
                                      subtables,
@@ -328,13 +328,13 @@ class PostgresTarget():
         new_properties = {}
         for prop, item_json_schema in table_json_schema['properties'].items():
             if current_path:
-                next_path = current_path + self.NESTED_SEPARATOR + prop
+                next_path = current_path + self.SEPARATOR + prop
             else:
                 next_path = prop
 
             if json_schema.is_object(item_json_schema):
                 not_null = 'null' not in item_json_schema['type']
-                self.denest_schema_helper(table_name + self.NESTED_SEPARATOR + next_path,
+                self.denest_schema_helper(table_name + self.SEPARATOR + next_path,
                                           item_json_schema,
                                           not_null,
                                           new_properties,
@@ -343,7 +343,7 @@ class PostgresTarget():
                                           subtables,
                                           level)
             elif json_schema.is_iterable(item_json_schema):
-                self.create_subtable(table_name + self.NESTED_SEPARATOR + next_path,
+                self.create_subtable(table_name + self.SEPARATOR + next_path,
                                      item_json_schema,
                                      key_prop_schemas,
                                      subtables,
@@ -362,11 +362,11 @@ class PostgresTarget():
                          pk_fks,
                          level):
         for prop, value in record.items():
-            next_path = current_path + self.NESTED_SEPARATOR + prop
+            next_path = current_path + self.SEPARATOR + prop
             if isinstance(value, dict):
                 self.denest_subrecord(table_name, next_path, parent_record, value, pk_fks, level)
             elif isinstance(value, list):
-                self.denest_records(table_name + self.NESTED_SEPARATOR + next_path,
+                self.denest_records(table_name + self.SEPARATOR + next_path,
                                     value,
                                     records_map,
                                     key_properties,
@@ -379,7 +379,7 @@ class PostgresTarget():
         denested_record = {}
         for prop, value in record.items():
             if current_path:
-                next_path = current_path + self.NESTED_SEPARATOR + prop
+                next_path = current_path + self.SEPARATOR + prop
             else:
                 next_path = prop
 
@@ -393,7 +393,7 @@ class PostgresTarget():
                                       pk_fks,
                                       level)
             elif isinstance(value, list):
-                self.denest_records(table_name + self.NESTED_SEPARATOR + next_path,
+                self.denest_records(table_name + self.SEPARATOR + next_path,
                                     value,
                                     records_map,
                                     key_properties,
@@ -678,7 +678,7 @@ class PostgresTarget():
             self.add_column(cur, table_schema, table_name, prop, column_json_schema)
 
     def get_temp_table_name(self, stream_name):
-        return stream_name + self.NESTED_SEPARATOR + str(uuid.uuid4()).replace('-', '')
+        return stream_name + self.SEPARATOR + str(uuid.uuid4()).replace('-', '')
 
     def get_table_metadata(self, cur, table_schema, table_name):
         cur.execute(

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -428,3 +428,9 @@ def test_make_nullable():
             'properties': {
                 'billing_address': {'$ref': '#/definitions/address'},
                 'shipping_address': {'$ref': '#/definitions/address'}}})
+
+
+def test_sql_shorthand():
+    assert 'b' == json_schema.sql_shorthand({'type': 'boolean'})
+    assert 'b' == json_schema.sql_shorthand({'type': ['null', 'boolean']})
+    assert 's' == json_schema.sql_shorthand({'type': ['null', 'string']})

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -282,9 +282,25 @@ def test_loading__new_non_null_column(db_cleanup):
 
 
 def test_loading__column_type_change(db_cleanup):
+    stream = CatStream(20)
+    stream.schema = deepcopy(stream.schema)
+    stream.schema['schema']['properties']['paw_toe_count'] = {'type': 'string',
+                                                              'default': 'five'}
+
     main(CONFIG, input_stream=CatStream(100))
 
-    with pytest.raises(postgres.PostgresError, match=r'Column type change detected.*'):
+    stream = CatStream(20)
+    stream.schema = deepcopy(stream.schema)
+    stream.schema['schema']['properties']['paw_toe_count'] = {'type': 'integer',
+                                                              'default': 5}
+
+    main(CONFIG, input_stream=stream)
+
+
+def test_loading__column_type_change__nullable(db_cleanup):
+    main(CONFIG, input_stream=CatStream(100))
+
+    with pytest.raises(postgres.PostgresError, match=r'Cannot handle column type change.*'):
         stream = CatStream(20)
         stream.schema = deepcopy(stream.schema)
         stream.schema['schema']['properties']['name']['type'].append('null')


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/issues/12

Presently if a column comes to us with a type change, we are unable to handle the type change. The work done in this pr:

- detects the type change
- creates two new columns:
  - `<original-column-name>__<existing-type:sql-type-shortand>`
  - `<original-column-name>__<new-type:sql-type-shortand>`
- migrates the data from `<original-column-name>` to `<original-column-name>__<existing-type:sql-type-shortand>`
- drops `<original-column-name>`

## Notes

- This lays some groundwork for future `$any` support
- This lays some groundwork for future `regular-type -> null-type` support but does not implement the work to do this

## Suggested Musical Pairing

Dog sleeping.