### PR TITLE
Refactor/sql persist

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -360,7 +360,7 @@ class PostgresTarget(SQLInterface):
                           remote_schema['version'])
 
         ## Make streamable CSV records
-        csv_headers = writeable_batch['records'][0].keys()
+        csv_headers = list(remote_schema['schema']['properties'].keys())
         rows_iter = iter(writeable_batch['records'])
 
         def transform():
@@ -368,7 +368,7 @@ class PostgresTarget(SQLInterface):
                 row = next(rows_iter)
 
                 with io.StringIO() as out:
-                    writer = csv.DictWriter(out, row.keys())
+                    writer = csv.DictWriter(out, csv_headers)
                     writer.writerow(row)
                     return out.getvalue()
             except StopIteration:

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -4,7 +4,6 @@ import csv
 import uuid
 import json
 from functools import partial
-from copy import deepcopy
 
 import arrow
 from psycopg2 import sql
@@ -17,7 +16,6 @@ from target_postgres.singer_stream import (
     SINGER_SEQUENCE,
     SINGER_TABLE_VERSION,
     SINGER_PK,
-    SINGER_SOURCE_PK_PREFIX,
     SINGER_LEVEL
 )
 
@@ -29,7 +27,7 @@ class PostgresError(Exception):
     Raise this when there is an error with regards to Postgres streaming
     """
 
-class TransformStream():
+class TransformStream:
     def __init__(self, fun):
         self.fun = fun
 
@@ -86,7 +84,7 @@ class PostgresTarget(SQLInterface):
 
                 if current_table_version is not None and \
                         min(versions) < current_table_version:
-                    self.logger.warning('{} - Records from an earlier table vesion detected.'
+                    self.logger.warning('{} - Records from an earlier table version detected.'
                                         .format(stream_buffer.stream))
                 if len(versions) > 1:
                     self.logger.warning('{} - Multiple table versions in stream, only using the latest.'

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -400,7 +400,7 @@ class SQLInterface:
         :param value: literal
         :return: string
         """
-        raise NotImplementedError('`parse_table_record_serialize_field_name` not implmented.')
+        raise NotImplementedError('`parse_table_record_serialize_field_name` not implemented.')
 
     def parse_table_record_serialize_null_value(
             self, remote_schema, streamed_schema, field, value):
@@ -411,9 +411,9 @@ class SQLInterface:
         :param streamed_schema: TABLE_SCHEMA(local)
         :param field: string
         :param value: literal
-        :return: literal
+        :return: literalg
         """
-        raise NotImplementedError('`parse_table_record_serialize_null_value` not implmented.')
+        raise NotImplementedError('`parse_table_record_serialize_null_value` not implemented.')
 
     def parse_table_record_serialize_datetime_value(
             self, remote_schema, streamed_schema, field, value):
@@ -427,7 +427,7 @@ class SQLInterface:
         :return: literal
         """
 
-        raise NotImplementedError('`parse_table_record_serialize_datetime_value` not implmented.')
+        raise NotImplementedError('`parse_table_record_serialize_datetime_value` not implemented.')
 
     def parse_table_records_serialize_for_remote(
             self, remote_schema, streamed_schema, records):

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -206,6 +206,7 @@ class SQLInterface:
 
     def get_table_schema(self, connection, name):
         """
+        Fetch the `table_schema` for `name`.
         :param connection: remote connection, type left to be determined by implementing class
         :param name: string
         :return: TABLE_SCHEMA(remote)
@@ -214,7 +215,8 @@ class SQLInterface:
 
     def update_table_schema(self, connection, remote_table_json_schema, table_json_schema, metadata):
         """
-
+        Update the remote table schema based on the merged difference between
+        `remote_table_json_schema` and `table_json_schema`.
         :param connection: remote connection, type left to be determined by implementing class
         :param remote_table_json_schema: get_table_schema
         :param table_json_schema: updates for get_table_schema


### PR DESCRIPTION
# Motivation
https://github.com/datamill-co/target-postgres/projects/1#card-14578993

Follow up to the work done in #41. This PR seeks to start tackling the commonality of `write_batch` for `SQLInterface`.

## Notes
This pr moves the following functionality over to `sql_base`:
- records denesting per table
- records serialization preparation for remote persistence

This pr _removes_ the following functionality from `sql_base`:
- bulk/entire schema updating for remote
  - it leaves in place updating _individual_ tables

## Suggested Musical Pairing
https://soundcloud.com/subpop/rolling-blackouts-julies-place