### PR TITLE
Feature/invalid identifier names

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ _The above is copied from the [current list of versions](https://www.postgresql.
         - `['integer', 'number']`
         - `['any']`
         - `['null']`
-- Types cannot change
 - JSON Schema combinations such as `anyOf` and `allOf` are not supported.
 - JSON Schema $ref is partially supported:
   - ***NOTE:*** The following limitations are known to **NOT** fail gracefully
@@ -105,10 +104,14 @@ _The above is copied from the [current list of versions](https://www.postgresql.
     - URI's do not work
     - if the `$ref` is broken, the behaviour is considered unexpected
 - Any values which are the `string` `NULL` will be streamed to PostgreSQL as the literal `null`
+- Field/Column/Table identifiers are restricted to:
+  - 63 characters in length
+  - can only be composed of `_`, lowercase letters, numbers, `$`
+  - cannot start with `$`
 
 ## Usage Logging
 
-[Singer.io](https://www.singer.io/) requires offical taps and targets to collect anonymous usage data. This data is only used in aggregate to report on individual tap/targets, as well as the Singer community at-large. IP addresses are recorded to detect unique tap/targets users but not shared with third-parties.
+[Singer.io](https://www.singer.io/) requires official taps and targets to collect anonymous usage data. This data is only used in aggregate to report on individual tap/targets, as well as the Singer community at-large. IP addresses are recorded to detect unique tap/targets users but not shared with third-parties.
 
 To disable anonymous data collection set `disable_collection` to `true` in the configuration JSON file.
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,14 @@ _The above is copied from the [current list of versions](https://www.postgresql.
     - URI's do not work
     - if the `$ref` is broken, the behaviour is considered unexpected
 - Any values which are the `string` `NULL` will be streamed to PostgreSQL as the literal `null`
-- Field/Column/Table identifiers are restricted to:
+- Table identifiers are restricted to:
   - 63 characters in length
   - can only be composed of `_`, lowercase letters, numbers, `$`
   - cannot start with `$`
+  - ASCII characters
+- Field/Column identifiers are restricted to:
+  - 63 characters in length
+  - ASCII characters
 
 ## Usage Logging
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ _The above is copied from the [current list of versions](https://www.postgresql.
     - URI's do not work
     - if the `$ref` is broken, the behaviour is considered unexpected
 - Any values which are the `string` `NULL` will be streamed to PostgreSQL as the literal `null`
-- Table identifiers are restricted to:
+- Table names are restricted to:
   - 63 characters in length
   - can only be composed of `_`, lowercase letters, numbers, `$`
   - cannot start with `$`
   - ASCII characters
-- Field/Column identifiers are restricted to:
+- Field/Column names are restricted to:
   - 63 characters in length
   - ASCII characters
 

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -439,17 +439,13 @@ class PostgresTarget(SQLInterface):
         try:
             cur.execute(to_execute)
         except Exception as ex:
-            ## Name collision with non mapped, non canonicalized name
-            if column_name != canonicalized_name:
-                raise PostgresError(
-                    'Cannot add canonicalized column `{}` as `{}` to table `{}` with schema {}. Name collision likely'.format(
-                        column_name,
-                        canonicalized_name,
-                        table_name,
-                        str(column_schema)
-                    ))
-            else:
-                raise ex
+            raise PostgresError(
+                'Cannot add column `{}` with canonicalized name `{}` to table `{}` with schema {}.'.format(
+                    canonicalized_name,
+                    column_name,
+                    table_name,
+                    str(column_schema)
+                )) from ex
 
     def migrate_column(self, cur, table_name, column_name, mapped_name):
         cur.execute(sql.SQL('UPDATE {table_schema}.{table_name} ' +

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -517,22 +517,34 @@ def test_loading__invalid__column_name(db_cleanup):
     non_alphanumeric_stream.schema = deepcopy(non_alphanumeric_stream.schema)
     non_alphanumeric_stream.schema['schema']['properties']['!!!invalid_name'] = non_alphanumeric_stream.schema['schema']['properties']['age']
 
-    with pytest.raises(postgres.PostgresError):
-        main(CONFIG, input_stream=non_alphanumeric_stream)
+    main(CONFIG, input_stream=non_alphanumeric_stream)
 
     non_lowercase_stream = CatStream(100)
     non_lowercase_stream.schema = deepcopy(non_lowercase_stream.schema)
     non_lowercase_stream.schema['schema']['properties']['INVALID_name'] = non_lowercase_stream.schema['schema']['properties']['age']
 
-    with pytest.raises(postgres.PostgresError):
-        main(CONFIG, input_stream=non_lowercase_stream)
+    main(CONFIG, input_stream=non_lowercase_stream)
 
+def test_loading__invalid__column_name__non_canonicalizable(db_cleanup):
     name_too_long_stream = CatStream(100)
     name_too_long_stream.schema = deepcopy(name_too_long_stream.schema)
     name_too_long_stream.schema['schema']['properties']['x' * 1000] = name_too_long_stream.schema['schema']['properties']['age']
 
     with pytest.raises(postgres.PostgresError):
         main(CONFIG, input_stream=name_too_long_stream)
+
+    non_lowercase_stream = CatStream(100)
+    non_lowercase_stream.schema = deepcopy(non_lowercase_stream.schema)
+    non_lowercase_stream.schema['schema']['properties']['INVALID_name'] = non_lowercase_stream.schema['schema']['properties']['age']
+
+    main(CONFIG, input_stream=non_lowercase_stream)
+
+    duplicate_canonicalization_stream = CatStream(100)
+    duplicate_canonicalization_stream.schema = deepcopy(duplicate_canonicalization_stream.schema)
+    duplicate_canonicalization_stream.schema['schema']['properties']['invalid!NAME'] = duplicate_canonicalization_stream.schema['schema']['properties']['age']
+
+    with pytest.raises(postgres.PostgresError):
+        main(CONFIG, input_stream=duplicate_canonicalization_stream)
 
 
 def test_loading__invalid__column_type_change__pks():


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/issues/18

When we get an identifier for a column/table which is invalid for PostgreSQL we presently don't do anything intelligent and simply try to persist it to the remote target.

This PR aims to do a few things:
- alert users with a fine grained description of the problem by both detecting when there could be a problem and also by detecting when a problem has occurred in the remote and providing details
- map invalid _column_ names to valid names by:
  - lowercasing all names
  - stripping invalid characters and replacing them with `_`
- start building out the usage of `mappings` and exploring commonality of this mechanism
  - my _guess_ is that we will want to make this a universal `SQLInterface` type thing, but for the time being we can leave this alone and keep this a feature specific pr

## Suggested Musical Pairing

https://soundcloud.com/wmi/metronomy-04-love-letters-2?in=metronomy/sets/love-letters-19