### PR TITLE
Fix/table name validation detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ _The above is copied from the [current list of versions](https://www.postgresql.
         - `['integer', 'number']`
         - `['any']`
         - `['null']`
-- Types cannot change
 - JSON Schema combinations such as `anyOf` and `allOf` are not supported.
 - JSON Schema $ref is partially supported:
   - ***NOTE:*** The following limitations are known to **NOT** fail gracefully
@@ -105,10 +104,14 @@ _The above is copied from the [current list of versions](https://www.postgresql.
     - URI's do not work
     - if the `$ref` is broken, the behaviour is considered unexpected
 - Any values which are the `string` `NULL` will be streamed to PostgreSQL as the literal `null`
+- Field/Column/Table identifiers are restricted to:
+  - 63 characters in length
+  - can only be composed of `_`, lowercase letters, numbers, `$`
+  - cannot start with `$`
 
 ## Usage Logging
 
-[Singer.io](https://www.singer.io/) requires offical taps and targets to collect anonymous usage data. This data is only used in aggregate to report on individual tap/targets, as well as the Singer community at-large. IP addresses are recorded to detect unique tap/targets users but not shared with third-parties.
+[Singer.io](https://www.singer.io/) requires official taps and targets to collect anonymous usage data. This data is only used in aggregate to report on individual tap/targets, as well as the Singer community at-large. IP addresses are recorded to detect unique tap/targets users but not shared with third-parties.
 
 To disable anonymous data collection set `disable_collection` to `true` in the configuration JSON file.
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,14 @@ _The above is copied from the [current list of versions](https://www.postgresql.
     - URI's do not work
     - if the `$ref` is broken, the behaviour is considered unexpected
 - Any values which are the `string` `NULL` will be streamed to PostgreSQL as the literal `null`
-- Field/Column/Table identifiers are restricted to:
+- Table identifiers are restricted to:
   - 63 characters in length
   - can only be composed of `_`, lowercase letters, numbers, `$`
   - cannot start with `$`
+  - ASCII characters
+- Field/Column identifiers are restricted to:
+  - 63 characters in length
+  - ASCII characters
 
 ## Usage Logging
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ _The above is copied from the [current list of versions](https://www.postgresql.
     - URI's do not work
     - if the `$ref` is broken, the behaviour is considered unexpected
 - Any values which are the `string` `NULL` will be streamed to PostgreSQL as the literal `null`
-- Table identifiers are restricted to:
+- Table names are restricted to:
   - 63 characters in length
   - can only be composed of `_`, lowercase letters, numbers, `$`
   - cannot start with `$`
   - ASCII characters
-- Field/Column identifiers are restricted to:
+- Field/Column names are restricted to:
   - 63 characters in length
   - ASCII characters
 

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -439,17 +439,13 @@ class PostgresTarget(SQLInterface):
         try:
             cur.execute(to_execute)
         except Exception as ex:
-            ## Name collision with non mapped, non canonicalized name
-            if column_name != canonicalized_name:
-                raise PostgresError(
-                    'Cannot add canonicalized column `{}` as `{}` to table `{}` with schema {}. Name collision likely'.format(
-                        column_name,
-                        canonicalized_name,
-                        table_name,
-                        str(column_schema)
-                    ))
-            else:
-                raise ex
+            raise PostgresError(
+                'Cannot add column `{}` with canonicalized name `{}` to table `{}` with schema {}.'.format(
+                    canonicalized_name,
+                    column_name,
+                    table_name,
+                    str(column_schema)
+                )) from ex
 
     def migrate_column(self, cur, table_name, column_name, mapped_name):
         cur.execute(sql.SQL('UPDATE {table_schema}.{table_name} ' +

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -372,7 +372,7 @@ class PostgresTarget(SQLInterface):
     def write_table_batch(self, cur, table_batch, metadata):
         remote_schema = table_batch['remote_schema']
 
-        target_table_name = self.get_temp_table_name(remote_schema['name'])
+        target_table_name = self.get_temp_table_name()
 
         ## Create temp table to upload new data to
         self.create_table(cur,
@@ -510,8 +510,8 @@ class PostgresTarget(SQLInterface):
                                remote_table_json_schema,
                                schema)
 
-    def get_temp_table_name(self, stream_name):
-        return stream_name + SEPARATOR + str(uuid.uuid4()).replace('-', '')
+    def get_temp_table_name(self):
+        return 'tmp_' + str(uuid.uuid4()).replace('-', '_')
 
     def get_table_metadata(self, cur, table_name):
         cur.execute(

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -490,6 +490,8 @@ class PostgresTarget(SQLInterface):
 
 
     def create_table(self, cur, table_name, schema, table_version):
+        self._validate_identifier(table_name)
+
         create_table_sql = sql.SQL('CREATE TABLE {}.{}').format(
                 sql.Identifier(self.postgres_schema),
                 sql.Identifier(table_name))

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -517,22 +517,34 @@ def test_loading__invalid__column_name(db_cleanup):
     non_alphanumeric_stream.schema = deepcopy(non_alphanumeric_stream.schema)
     non_alphanumeric_stream.schema['schema']['properties']['!!!invalid_name'] = non_alphanumeric_stream.schema['schema']['properties']['age']
 
-    with pytest.raises(postgres.PostgresError):
-        main(CONFIG, input_stream=non_alphanumeric_stream)
+    main(CONFIG, input_stream=non_alphanumeric_stream)
 
     non_lowercase_stream = CatStream(100)
     non_lowercase_stream.schema = deepcopy(non_lowercase_stream.schema)
     non_lowercase_stream.schema['schema']['properties']['INVALID_name'] = non_lowercase_stream.schema['schema']['properties']['age']
 
-    with pytest.raises(postgres.PostgresError):
-        main(CONFIG, input_stream=non_lowercase_stream)
+    main(CONFIG, input_stream=non_lowercase_stream)
 
+def test_loading__invalid__column_name__non_canonicalizable(db_cleanup):
     name_too_long_stream = CatStream(100)
     name_too_long_stream.schema = deepcopy(name_too_long_stream.schema)
     name_too_long_stream.schema['schema']['properties']['x' * 1000] = name_too_long_stream.schema['schema']['properties']['age']
 
     with pytest.raises(postgres.PostgresError):
         main(CONFIG, input_stream=name_too_long_stream)
+
+    non_lowercase_stream = CatStream(100)
+    non_lowercase_stream.schema = deepcopy(non_lowercase_stream.schema)
+    non_lowercase_stream.schema['schema']['properties']['INVALID_name'] = non_lowercase_stream.schema['schema']['properties']['age']
+
+    main(CONFIG, input_stream=non_lowercase_stream)
+
+    duplicate_canonicalization_stream = CatStream(100)
+    duplicate_canonicalization_stream.schema = deepcopy(duplicate_canonicalization_stream.schema)
+    duplicate_canonicalization_stream.schema['schema']['properties']['invalid!NAME'] = duplicate_canonicalization_stream.schema['schema']['properties']['age']
+
+    with pytest.raises(postgres.PostgresError):
+        main(CONFIG, input_stream=duplicate_canonicalization_stream)
 
 
 def test_loading__invalid__column_type_change__pks():


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/issues/18#issuecomment-443284112

```
target_postgres_test=# create table cats__1__adoption__immunizations__5d3f791dacf047c0ae3cebefe2af74b2 ();
NOTICE:  identifier "cats__1__adoption__immunizations__5d3f791dacf047c0ae3cebefe2af74b2" will be truncated to "cats__1__adoption__immunizations__5d3f791dacf047c0ae3cebefe2af7"
CREATE TABLE

```

That's the name of one of the temp tables we generate. That just _happens_ to work right now. This pr removes the variability in temp table name generation length and instead just uses a `uuid` to uniquely identify tmps.

## Suggested Musical Pairing

https://soundcloud.com/unknownmortalorchestra/hunnybee