### PR TITLE
Fix/remove collaborators from synced

### DIFF
--- a/.circleci/integration/tap-github/properties.json
+++ b/.circleci/integration/tap-github/properties.json
@@ -1502,7 +1502,7 @@
       "stream": "collaborators",
       "tap_stream_id": "collaborators",
       "schema": {
-        "selected": true,
+        "selected": false,
         "type": [
           "null",
           "object"


### PR DESCRIPTION
# Motivation

https://circleci.com/gh/datamill-co/target-postgres/108

Master is failing due to https://github.com/singer-io/tap-github/pull/39

## Testing

To test this, I ssh'ed into the mentioned CCI container above and did the following:

```
... install vim...
(venv--tap-github) root@b69bd62441ff:/code/.circleci/integration/tap-github# vim properties.json 
## Updated properties to selected: false for Collaborators
(venv--tap-github) root@b69bd62441ff:/code/.circleci/integration/tap-github# tap-github --config config.json --properties properties.json > /code/artifacts/data/tap
...
(venv--tap-github) root@b69bd62441ff:/code/.circleci/integration/tap-github# echo $?
0
```

## Suggested Musical Pairing

https://soundcloud.com/littledragon/lover-chanting