### PR TITLE
Fix/old table versions overwrite current table

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -101,11 +101,13 @@ class PostgresTarget(SQLInterface):
                     self.logger.warning('{} - Multiple table versions in stream, only using the latest.'
                                         .format(stream_buffer.stream))
 
+                root_table_name = stream_buffer.stream
+
                 if current_table_version is not None and \
                         target_table_version > current_table_version:
                     root_table_name = stream_buffer.stream + SEPARATOR + str(target_table_version)
-                else:
-                    root_table_name = stream_buffer.stream
+                elif current_table_version:
+                    target_table_version = current_table_version
 
                 if target_table_version is not None:
                     records = list(filter(lambda x: x.get(SINGER_TABLE_VERSION) == target_table_version,
@@ -157,7 +159,7 @@ class PostgresTarget(SQLInterface):
                 if not table_metadata:
                     self.logger.error('{} - Table for stream does not exist'.format(
                         stream_buffer.stream))
-                elif table_metadata.get('version') == version:
+                elif table_metadata.get('version') is not None and table_metadata.get('version') >= version:
                     self.logger.warning('{} - Table version {} already active'.format(
                         stream_buffer.stream,
                         version))

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1179,6 +1179,17 @@ def test_full_table_replication(db_cleanup):
     assert version_2_count == 120
     assert version_2_sub_count == 240
 
+    ## Test that an outdated version cannot overwrite
+    stream = CatStream(314, version=1, nested_count=2)
+    main(CONFIG, input_stream=stream)
+
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('cats'))
+            older_version_count = cur.fetchone()[0]
+
+    assert older_version_count == version_2_count
+
 
 def test_deduplication_newer_rows(db_cleanup):
     stream = CatStream(100, nested_count=3, duplicates=2)


### PR DESCRIPTION
# Motivation

While working on some refactoring/feature work I stumbled across an oddity in dealing with table versions. Presently, you can blow away _all_ current data if a message for `ACTIVATE_VERSION` comes across which is for an older table version.

In reading up on `ACTIVATE_VERSION` from Singer, I do _not_ think this is the intention of this message.

## Suggested Musical

https://soundcloud.com/thomyorkeofficial/suspirium