### PR TITLE
Performance/singer stream retain latest records only

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -29,6 +29,7 @@ class TargetError(Exception):
 
 def flush_stream(target, stream_buffer):
     target.write_batch(stream_buffer)
+    stream_buffer.flush_buffer()
 
 def flush_streams(streams, target, force=False):
     for stream_buffer in streams.values():

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -101,11 +101,13 @@ class PostgresTarget(SQLInterface):
                     self.logger.warning('{} - Multiple table versions in stream, only using the latest.'
                                         .format(stream_buffer.stream))
 
+                root_table_name = stream_buffer.stream
+
                 if current_table_version is not None and \
                         target_table_version > current_table_version:
                     root_table_name = stream_buffer.stream + SEPARATOR + str(target_table_version)
-                else:
-                    root_table_name = stream_buffer.stream
+                elif current_table_version:
+                    target_table_version = current_table_version
 
                 if target_table_version is not None:
                     records = list(filter(lambda x: x.get(SINGER_TABLE_VERSION) == target_table_version,
@@ -157,7 +159,7 @@ class PostgresTarget(SQLInterface):
                 if not table_metadata:
                     self.logger.error('{} - Table for stream does not exist'.format(
                         stream_buffer.stream))
-                elif table_metadata.get('version') == version:
+                elif table_metadata.get('version') is not None and table_metadata.get('version') >= version:
                     self.logger.warning('{} - Table version {} already active'.format(
                         stream_buffer.stream,
                         version))

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -84,6 +84,10 @@ class BufferedSingerStream():
 
         return False
 
+    @property
+    def max_version(self):
+        return self.__lifetime_max_version
+
     def __update_version(self, version):
         if version is None or (self.__lifetime_max_version is not None and self.__lifetime_max_version >= version):
             return None

--- a/tests/test_BufferedSingerStream.py
+++ b/tests/test_BufferedSingerStream.py
@@ -60,3 +60,115 @@ def test_add_record_message__invalid_record__cross_threshold():
 
     assert singer_stream.peek_invalid_records()
     assert singer_stream.count == 0
+
+
+def mocked_mock_write_batch(stream_buffer):
+    stream_buffer.flush_buffer()
+
+
+def test_multiple_batches__by_rows():
+    stream = CatStream(100)
+
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'],
+                                         max_rows=20)
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+    while not singer_stream.buffer_full:
+        singer_stream.add_record_message(stream.generate_record_message())
+
+    assert len(singer_stream.peek_buffer()) == 20
+
+    singer_stream.flush_buffer()
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+
+def test_multiple_batches__by_memory():
+    stream = CatStream(100)
+
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'],
+                                         max_buffer_size=1024)
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+    while not singer_stream.buffer_full:
+        singer_stream.add_record_message(stream.generate_record_message())
+
+    assert len(singer_stream.peek_buffer()) == 1
+
+    singer_stream.flush_buffer()
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+
+def test_multiple_batches__old_records__by_rows():
+    stream_oldest = CatStream(100, version=0)
+    stream_middle_aged = CatStream(100, version=5)
+    stream_latest = CatStream(100, version=10)
+
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'],
+                                         max_rows=20)
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+    while not singer_stream.buffer_full:
+        singer_stream.add_record_message(stream_oldest.generate_record_message())
+
+    assert len(singer_stream.peek_buffer()) == 20
+
+    singer_stream.flush_buffer()
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+    singer_stream.add_record_message(stream_latest.generate_record_message())
+
+    assert len(singer_stream.peek_buffer()) == 1
+
+    reasonable_cutoff = 1000
+    while not singer_stream.buffer_full and reasonable_cutoff != 0:
+        singer_stream.add_record_message(stream_middle_aged.generate_record_message())
+        reasonable_cutoff -= 1
+
+    assert reasonable_cutoff == 0
+    assert len(singer_stream.peek_buffer()) == 1
+
+
+def test_multiple_batches__old_records__by_memory():
+    stream_oldest = CatStream(100, version=0)
+    stream_middle_aged = CatStream(100, version=5)
+    stream_latest = CatStream(100, version=10)
+
+    singer_stream = BufferedSingerStream(CATS_SCHEMA['stream'],
+                                         CATS_SCHEMA['schema'],
+                                         CATS_SCHEMA['key_properties'],
+                                         max_buffer_size=32768)
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+    while not singer_stream.buffer_full:
+        singer_stream.add_record_message(stream_oldest.generate_record_message())
+
+    assert len(singer_stream.peek_buffer()) > 0
+
+    singer_stream.flush_buffer()
+
+    assert len(singer_stream.peek_buffer()) == 0
+
+    singer_stream.add_record_message(stream_latest.generate_record_message())
+
+    assert len(singer_stream.peek_buffer()) == 1
+
+    reasonable_cutoff = 1000
+    while not singer_stream.buffer_full and reasonable_cutoff != 0:
+        singer_stream.add_record_message(stream_middle_aged.generate_record_message())
+        reasonable_cutoff -= 1
+
+    assert reasonable_cutoff == 0
+    assert len(singer_stream.peek_buffer()) == 1

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from datetime import datetime
-from unittest.mock import patch
 
 import psycopg2
 from psycopg2 import sql
@@ -1263,38 +1262,6 @@ def test_deduplication_existing_new_rows(db_cleanup):
 
     assert len(sequences) == 1
     assert sequences[0][0] == original_sequence
-
-
-def mocked_mock_write_batch(stream_buffer):
-    records = stream_buffer.flush_buffer()
-
-
-def test_multiple_batches_by_rows(db_cleanup):
-    with patch.object(postgres.PostgresTarget,
-                      'write_batch',
-                      side_effect=mocked_mock_write_batch) as mock_write_batch:
-        config = CONFIG.copy()
-        config['max_batch_rows'] = 20
-        config['batch_detection_threshold'] = 5
-
-        stream = CatStream(100)
-        main(config, input_stream=stream)
-
-        assert mock_write_batch.call_count == 6
-
-
-def test_multiple_batches_by_memory(db_cleanup):
-    with patch.object(postgres.PostgresTarget,
-                      'write_batch',
-                      side_effect=mocked_mock_write_batch) as mock_write_batch:
-        config = CONFIG.copy()
-        config['max_batch_size'] = 1024
-        config['batch_detection_threshold'] = 5
-
-        stream = CatStream(100)
-        main(config, input_stream=stream)
-
-        assert mock_write_batch.call_count == 21
 
 
 def test_multiple_batches_upsert(db_cleanup):

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1179,6 +1179,17 @@ def test_full_table_replication(db_cleanup):
     assert version_2_count == 120
     assert version_2_sub_count == 240
 
+    ## Test that an outdated version cannot overwrite
+    stream = CatStream(314, version=1, nested_count=2)
+    main(CONFIG, input_stream=stream)
+
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('cats'))
+            older_version_count = cur.fetchone()[0]
+
+    assert older_version_count == version_2_count
+
 
 def test_deduplication_newer_rows(db_cleanup):
     stream = CatStream(100, nested_count=3, duplicates=2)


### PR DESCRIPTION
# Motivation

While refactoring `target-postgres` to make addition of more dialects simpler, I noticed that the Singer Stream could easily do more with versions etc., and make the interface for writing a batch of data to remote much simpler.

## Suggested Musical Pairing

https://soundcloud.com/miikesnow/silvia