### PR TITLE
Feature/sql interface logger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ test__base: &test__base
   steps:
     - checkout
     - *restore__cache
+    - attach_workspace:
+        at: "./"
 
     - run:
         name: Run Tests
@@ -95,6 +97,11 @@ jobs:
             - "/usr/local/bin"
             - "/usr/local/lib/python3.7/site-packages"
 
+      - persist_to_workspace:
+          root: "./"
+          paths:
+            - "./venv--target-postgres"
+
   test--11.1:
     <<: *test__base
     docker:
@@ -137,6 +144,8 @@ jobs:
     steps:
       - checkout
       - *restore__cache
+      - attach_workspace:
+          at: "./"
 
       - run:
           name: Setup artifacts folder
@@ -182,6 +191,34 @@ jobs:
             tap-postgres --config config.json --properties /code/artifacts/data/properties.json > /code/artifacts/data/target
 
             deactivate
+
+      - run:
+          name: Repeatability of Data -> Target
+          command: |
+            source venv--target-postgres/bin/activate
+            cd /code/.circleci/integration
+
+            cat /code/artifacts/data/tap | target-postgres --config target-config.json
+
+            deactivate
+
+            cd /code
+
+            source venv--tap-postgres/bin/activate
+            cd /code/.circleci/integration/tap-postgres
+
+            tap-postgres --config config.json --discover > tmp-properties.json
+
+            ## Select _every_ table found in properties.
+            ##  row-count seems to only show up inside of the necessary metadata object...easier than multi-line-sed
+            sed 's/"row-count": 0,/"row-count": 0,"selected":true,/g' tmp-properties.json > /code/artifacts/data/properties.json
+
+            tap-postgres --config config.json --properties /code/artifacts/data/properties.json > /code/artifacts/data/target.repeated
+
+            deactivate
+
+            ## TODO: compare repeated data to insure that we only changed _sdc values
+            # diff /code/artifacts/data/target /code/artifacts/data/target.repeated
 
       - store_artifacts:
           path: /code/artifacts

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -38,9 +38,8 @@ class PostgresTarget(SQLInterface):
     # TODO: Figure out way to `SELECT` value from commands
     IDENTIFIER_FIELD_LENGTH = 63
 
-    def __init__(self, connection, logger, *args, postgres_schema='public', **kwargs):
+    def __init__(self, connection, *args, postgres_schema='public', **kwargs):
         self.conn = connection
-        self.logger = logger
         self.postgres_schema = postgres_schema
 
     def write_batch(self, stream_buffer):
@@ -88,7 +87,7 @@ class PostgresTarget(SQLInterface):
                 if current_table_version is not None and \
                         stream_buffer.max_version is not None:
                     if stream_buffer.max_version < current_table_version:
-                        self.logger.warning('{} - Records from an earlier table version detected.'
+                        self.LOGGER.warning('{} - Records from an earlier table version detected.'
                                             .format(stream_buffer.stream))
                         cur.execute('ROLLBACK;')
                         return None
@@ -111,7 +110,7 @@ class PostgresTarget(SQLInterface):
             except Exception as ex:
                 cur.execute('ROLLBACK;')
                 message = 'Exception writing records'
-                self.logger.exception(message)
+                self.LOGGER.exception(message)
                 raise PostgresError(message, ex)
 
     def activate_version(self, stream_buffer, version):
@@ -123,10 +122,10 @@ class PostgresTarget(SQLInterface):
                                                           stream_buffer.stream)
 
                 if not table_metadata:
-                    self.logger.error('{} - Table for stream does not exist'.format(
+                    self.LOGGER.error('{} - Table for stream does not exist'.format(
                         stream_buffer.stream))
                 elif table_metadata.get('version') is not None and table_metadata.get('version') >= version:
-                    self.logger.warning('{} - Table version {} already active'.format(
+                    self.LOGGER.warning('{} - Table version {} already active'.format(
                         stream_buffer.stream,
                         version))
                 else:
@@ -159,7 +158,7 @@ class PostgresTarget(SQLInterface):
                 message = '{} - Exception activating table version {}'.format(
                     stream_buffer.stream,
                     version)
-                self.logger.exception(message)
+                self.LOGGER.exception(message)
                 raise PostgresError(message, ex)
 
     def _validate_identifier(self, identifier):
@@ -467,7 +466,7 @@ class PostgresTarget(SQLInterface):
                 comment_meta = json.loads(comment)
             except Exception as ex:
                 message = 'Could not load table comment metadata'
-                self.logger.exception(message)
+                self.LOGGER.exception(message)
                 raise PostgresError(message, ex)
         else:
             comment_meta = None

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -74,8 +74,8 @@ class PostgresTarget(SQLInterface):
                             ))
 
                     for key in stream_buffer.key_properties:
-                        if json_schema.get_type(current_table_schema['schema']['properties'][key]) \
-                                != json_schema.get_type(stream_buffer.schema['properties'][key]):
+                        if json_schema.to_sql(current_table_schema['schema']['properties'][key]) \
+                                != json_schema.to_sql(stream_buffer.schema['properties'][key]):
                             raise PostgresError(
                                 ('`key_properties` type change detected for "{}". ' +
                                  'Existing values are: {}. ' +

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -79,10 +79,12 @@ class PostgresTarget(SQLInterface):
                             raise PostgresError(
                                 ('`key_properties` type change detected for "{}". ' +
                                  'Existing values are: {}. ' +
-                                 'Streamed values are: {}').format(
+                                 'Streamed values are: {}, {}, {}').format(
                                     key,
                                     json_schema.get_type(current_table_schema['schema']['properties'][key]),
-                                    json_schema.get_type(stream_buffer.schema['properties'][key])
+                                    json_schema.get_type(stream_buffer.schema['properties'][key]),
+                                    json_schema.to_sql(current_table_schema['schema']['properties'][key]),
+                                    json_schema.to_sql(stream_buffer.schema['properties'][key])
                                 ))
 
                 root_table_name = stream_buffer.stream

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -39,6 +39,10 @@ class PostgresTarget(SQLInterface):
     IDENTIFIER_FIELD_LENGTH = 63
 
     def __init__(self, connection, *args, postgres_schema='public', **kwargs):
+        self.LOGGER.info(
+            'PostgresTarget created with established connection: `{}`, PostgreSQL schema: `{}`'.format(connection.dsn,
+                                                                                                       postgres_schema))
+
         self.conn = connection
         self.postgres_schema = postgres_schema
 

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -438,22 +438,25 @@ class SQLInterface:
             canonicalized_column_name = raw_canonicalized_column_name[
                                         :self.IDENTIFIER_FIELD_LENGTH - len(raw_suffix)] + raw_suffix
 
+            self.LOGGER.warning(
+                'FIELD COLLISION: Field `{}` exists in remote already. No compatible type found. Appending type suffix: `{}`'.format(
+                    path,
+                    canonicalized_column_name
+                ))
+
         i = 0
         ## NAME COLLISION
         while canonicalized_column_name in existing_column_names:
+            self.LOGGER.warning(
+                'NAME COLLISION: Field `{}` collided with `{}` in remote. Adding new integer suffix...'.format(
+                    path,
+                    canonicalized_column_name
+                ))
+
             i += 1
             suffix = raw_suffix + SEPARATOR + str(i)
             canonicalized_column_name = raw_canonicalized_column_name[
                                         :self.IDENTIFIER_FIELD_LENGTH - len(suffix)] + suffix
-
-            # TODO: logger warn
-            ##raise Exception(
-            ##    'NAME COLLISION: Cannot handle merging column `{}` (canonicalized as: `{}`, canonicalized with type as: `{}`) in table `{}`.'.format(
-            ##        raw_column_name,
-            ##        canonicalized_column_name,
-            ##        canonicalized_typed_column_name,
-            ##        table_name
-            ##    ))
 
         return canonicalized_column_name
 
@@ -501,19 +504,16 @@ class SQLInterface:
         i = 0
         ## NAME COLLISION
         while canonicalized_name in to_from:
+            self.LOGGER.warning(
+                'NAME COLLISION: Table `{}` collided with `{}` in remote. Adding new integer suffix...'.format(
+                    from_path,
+                    canonicalized_name
+                ))
+
             i += 1
             suffix = SEPARATOR + str(i)
             canonicalized_name = raw_canonicalized_name[
                                  :self.IDENTIFIER_FIELD_LENGTH - len(suffix)] + suffix
-
-            # TODO: logger warn
-            ##raise Exception(
-            ##    'NAME COLLISION: Cannot handle merging column `{}` (canonicalized as: `{}`, canonicalized with type as: `{}`) in table `{}`.'.format(
-            ##        raw_column_name,
-            ##        canonicalized_column_name,
-            ##        canonicalized_typed_column_name,
-            ##        table_name
-            ##    ))
 
         return {'exists': False, 'to': canonicalized_name}
 
@@ -678,11 +678,10 @@ class SQLInterface:
             if not column_path in [m['from'] for m in mappings]:
                 ### NON EMPTY TABLE
                 if not table_empty:
-                    ## TODO: Use self.logger to warn
-                    # self.logger.warning('Forcing new column `{}.{}.{}` to be nullable due to table not empty.'.format(
-                    #     self.postgres_schema,
-                    #     table_name,
-                    #     column_name))
+                    self.LOGGER.warning(
+                        'NOT EMPTY: Forcing new column `{}` in table `{}` to be nullable due to table not empty.'.format(
+                            column_path,
+                            table_name))
                     column_schema = nullable_column_schema
 
                 self.add_column(connection,

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -14,6 +14,8 @@
 
 from copy import deepcopy
 
+import singer
+
 from target_postgres import json_schema
 from target_postgres.singer_stream import (
     SINGER_BATCHED_AT,
@@ -352,6 +354,7 @@ class SQLInterface:
     """
 
     IDENTIFIER_FIELD_LENGTH = NotImplementedError('`IDENTIFIER_FIELD_LENGTH` not implemented.')
+    LOGGER = singer.get_logger()
 
     def _get_streamed_table_schemas(self, schema, key_properties):
         """

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -141,7 +141,7 @@ def assert_records(conn, records, table_name, pks, match_pks=False):
                 assert sorted(list(persisted_records.keys())) == sorted(records_pks)
 
 
-def test_loading__invalid__configuration__schema():
+def test_loading__invalid__configuration__schema(db_cleanup):
     stream = CatStream(1)
     stream.schema = deepcopy(stream.schema)
     stream.schema['schema']['type'] = 'invalid type for a JSON Schema'
@@ -150,13 +150,13 @@ def test_loading__invalid__configuration__schema():
         main(CONFIG, input_stream=stream)
 
 
-def test_loading__invalid__records():
+def test_loading__invalid__records(db_cleanup):
     with pytest.raises(singer_stream.SingerStreamError, match=r'.*'):
         main(CONFIG,
              input_stream=InvalidCatStream(1))
 
 
-def test_loading__invalid__records__disable():
+def test_loading__invalid__records__disable(db_cleanup):
     config = deepcopy(CONFIG)
     config['invalid_records_detect'] = False
 
@@ -169,7 +169,7 @@ def test_loading__invalid__records__disable():
             assert_columns_equal(cur, 'cats', {})
 
 
-def test_loading__invalid__records__threshold():
+def test_loading__invalid__records__threshold(db_cleanup):
     config = deepcopy(CONFIG)
     config['invalid_records_threshold'] = 10
 
@@ -177,7 +177,7 @@ def test_loading__invalid__records__threshold():
         main(config, input_stream=InvalidCatStream(20))
 
 
-def test_loading__invalid__default_null_value__non_nullable_column():
+def test_loading__invalid__default_null_value__non_nullable_column(db_cleanup):
     class NullDefaultCatStream(CatStream):
 
         def generate_record(self):
@@ -1043,7 +1043,7 @@ def test_loading__invalid_column_name__column_type_change(db_cleanup):
             assert 0 == len([x for x in persisted_records if x[0] is None and x[1] is None and x[2] is None])
 
 
-def test_loading__invalid__column_type_change__pks():
+def test_loading__invalid__column_type_change__pks(db_cleanup):
     main(CONFIG, input_stream=CatStream(20))
 
     class StringIdCatStream(CatStream):
@@ -1060,7 +1060,7 @@ def test_loading__invalid__column_type_change__pks():
         main(CONFIG, input_stream=stream)
 
 
-def test_loading__invalid__column_type_change__pks__nullable():
+def test_loading__invalid__column_type_change__pks__nullable(db_cleanup):
     main(CONFIG, input_stream=CatStream(20))
 
     stream = CatStream(20)

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1043,6 +1043,20 @@ def test_loading__invalid_column_name__column_type_change(db_cleanup):
             assert 0 == len([x for x in persisted_records if x[0] is None and x[1] is None and x[2] is None])
 
 
+def test_loading__column_type_change__pks__same_resulting_type(db_cleanup):
+    stream = CatStream(20)
+    stream.schema = deepcopy(stream.schema)
+    stream.schema['schema']['properties']['id'] = {'type': ['integer', 'null']}
+
+    main(CONFIG, input_stream=stream)
+
+    stream = CatStream(20)
+    stream.schema = deepcopy(stream.schema)
+    stream.schema['schema']['properties']['id'] = {'type': ['null', 'integer']}
+
+    main(CONFIG, input_stream=stream)
+
+
 def test_loading__invalid__column_type_change__pks(db_cleanup):
     main(CONFIG, input_stream=CatStream(20))
 


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/issues/74

## Notes

While working on this, I found a "fun" bug in the form of pk type changes. I addressed this in the last two commits. The first to add in some failing tests, then the next to address it. It was a very simple problem.

Generated logging:

```
INFO Sending version information to singer.io. To disable sending anonymous usage data, set the config parameter "disable_collection" to true
INFO PostgresTarget created with established connection: `host=localhost port=5432 dbname=target_postgres_test user=postgres`, PostgreSQL schema: `public`
WARNING `STATE` Singer message type not supported
WARNING `STATE` Singer message type not supported
WARNING `STATE` Singer message type not supported
WARNING `STATE` Singer message type not supported
WARNING `STATE` Singer message type not supported
WARNING `STATE` Singer message type not supported
WARNING `STATE` Singer message type not supported
INFO Writing batch with 8 records for `stargazers` with `key_properties`: `['user_id']`
INFO Writing table batch schema for `('stargazers',)`
INFO Table batch schema written in 9.302 millis for `('stargazers',)`
INFO Writing table batch with 8 rows for `('stargazers',)`
INFO Table batch with 8 rows wrote 8 rows in 14.444 millis for ('stargazers',)
INFO Batch with 8 records wrote 8 rows in 24.122 millis for `stargazers`
INFO Writing batch with 2 records for `assignees` with `key_properties`: `['id']`
INFO Writing table batch schema for `('assignees',)`
INFO Table batch schema written in 7.503 millis for `('assignees',)`
INFO Writing table batch with 2 rows for `('assignees',)`
INFO Table batch with 2 rows wrote 2 rows in 9.543 millis for ('assignees',)
INFO Batch with 2 records wrote 2 rows in 17.352 millis for `assignees`
INFO Writing batch with 15 records for `issues` with `key_properties`: `['id']`
INFO Writing table batch schema for `('issues',)`
INFO Table batch schema written in 24.439 millis for `('issues',)`
INFO Writing table batch with 15 rows for `('issues',)`
INFO Table batch with 15 rows wrote 15 rows in 37.854 millis for ('issues',)
INFO Writing table batch schema for `('issues', 'labels')`
INFO Table batch schema written in 12.895999999999999 millis for `('issues', 'labels')`
INFO Writing table batch with 7 rows for `('issues', 'labels')`
INFO Table batch with 7 rows wrote 7 rows in 9.774 millis for ('issues', 'labels')
INFO Batch with 15 records wrote 22 rows in 86.48599999999999 millis for `issues`
INFO Writing batch with 106 records for `comments` with `key_properties`: `['id']`
INFO Writing table batch schema for `('comments',)`
INFO Table batch schema written in 18.346 millis for `('comments',)`
INFO Writing table batch with 106 rows for `('comments',)`
INFO Table batch with 106 rows wrote 106 rows in 95.837 millis for ('comments',)
INFO Batch with 106 records wrote 106 rows in 117.637 millis for `comments`
INFO Writing batch with 46 records for `pull_requests` with `key_properties`: `['id']`
INFO Writing table batch schema for `('pull_requests',)`
INFO Table batch schema written in 10.489 millis for `('pull_requests',)`
INFO Writing table batch with 46 rows for `('pull_requests',)`
INFO Table batch with 46 rows wrote 46 rows in 44.181 millis for ('pull_requests',)
INFO Batch with 46 records wrote 46 rows in 55.541 millis for `pull_requests`
INFO Writing batch with 74 records for `review_comments` with `key_properties`: `['id']`
INFO Writing table batch schema for `('review_comments',)`
INFO Table batch schema written in 22.326999999999998 millis for `('review_comments',)`
INFO Writing table batch with 74 rows for `('review_comments',)`
INFO Table batch with 74 rows wrote 74 rows in 86.96 millis for ('review_comments',)
INFO Batch with 74 records wrote 74 rows in 110.857 millis for `review_comments`
INFO Writing batch with 271 records for `commits` with `key_properties`: `['sha']`
INFO Writing table batch schema for `('commits',)`
INFO Table batch schema written in 11.918 millis for `('commits',)`
INFO Writing table batch with 271 rows for `('commits',)`
INFO Table batch with 271 rows wrote 271 rows in 166.243 millis for ('commits',)
INFO Writing table batch schema for `('commits', 'parents')`
INFO Table batch schema written in 10.906 millis for `('commits', 'parents')`
INFO Writing table batch with 331 rows for `('commits', 'parents')`
INFO Table batch with 331 rows wrote 331 rows in 24.37 millis for ('commits', 'parents')
INFO Batch with 271 records wrote 602 rows in 220.356 millis for `commits`
```

## Suggested Musical Pairing

https://soundcloud.com/planned_obsolescence/everybodys-got-to-learn