### PR TITLE
Housekeeping: Remove unused argument from PostgresTarget

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -151,7 +151,6 @@ def main(config, input_stream=None):
 
         postgres_target = PostgresTarget(
             connection,
-            LOGGER,
             postgres_schema=config.get('postgres_schema', 'public'))
 
         invalid_records_detect = config.get('invalid_records_detect')


### PR DESCRIPTION
# Motivation

Extra `LOGGER` argument still being passed into `PostgresTarget`.

## Suggested Musical Pairing

Seagulls.