### PR TITLE
Feature/postgres 8 4 compatible code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,10 @@ workflows:
           <<: *filters
           requires:
             - cache
+      - test--8.4.22:
+          <<: *filters
+          requires:
+            - cache
       - test--tap-github:
           <<: *filters
           requires:
@@ -167,6 +171,14 @@ jobs:
     docker:
       - image: python:3.7.1-stretch
       - image: postgres:9.4.20
+        environment:
+          POSTGRES_DB: target_postgres_test
+
+  test--8.4.22:
+    <<: *test__base
+    docker:
+      - image: python:3.7.1-stretch
+      - image: postgres:8.4.22
         environment:
           POSTGRES_DB: target_postgres_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
             - approve-release
 
 cache: &cache
-         deps-v5-{{ checksum "setup.py" }}
+         deps-v6-{{ checksum "setup.py" }}
 
 restore__cache: &restore__cache
   restore_cache:

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -188,3 +188,23 @@ string identifier which contains only characters which are allowed by the remote
 - This approach is inspired by what Stitch Data takes with `array` de-nesting.
 - The user experience for those using a SQL querying language is better for flat tables
   - as compared to something like [PostgreSQL's JSONB](https://www.postgresql.org/docs/9.4/datatype-json.html) support
+
+## Queries
+
+### What
+
+- When we write SQL at any given point, we have the option to use "latest" PostgreSQL features
+- We opt for features available from PostgreSQL 8.4.22 forward
+- We ***DO NOT*** support PostgreSQL 8.4.22
+  - any features/bugs issues based on this will be weighed against this decision as far as effort to benefit
+
+### Why
+
+- Supporting multiple versions of PostgreSQL has _thus far_ been fairly straightforward by adhering to only query support available in the _oldest_ version of supported PostgreSQL
+- By doing this, we only have one main code base, instead of many fractured versions which all employ the latest/greatest system functions/methods/tables/information schemas available
+- By using 8.4.22, supporting [Redshift](https://github.com/datamill-co/target-redshift) is made simpler
+  - Redshift was originally split from [PostgreSQL 8.0.2](https://docs.aws.amazon.com/redshift/latest/dg/c_redshift-and-postgres-sql.html)
+  - At some point, a _lot_ of work was done by AWS to make Redshift a "simple fork" of PostgreSQL 8.4
+- We do not _support_ PostgreSQL 8.4 simply because PostgreSQL does not support it anymore
+  - Our _only_ benefit to making 8.4 query language our target is Redshift
+  - When a new supported version of PostgreSQL comes along, and we undertake the effort to support it herein, if supporting it is simpler to do by breaking 8.4, we will move the necessary logic to [target-redshift](https://github.com/datamill-co/target-redshift)


### PR DESCRIPTION
# Motivation

In splitting the `target-redshift` code out, there are some Postgres specific changes which can be made to provide a simpler interface for Redshift. `DECISIONS` comment is posted in full below:

## DECISION

### Queries

#### What

- When we write SQL at any given point, we have the option to use "latest" PostgreSQL features
- We opt for features available from PostgreSQL 8.4.22 forward
- We ***DO NOT*** support PostgreSQL 8.4.22
  - any features/bugs issues based on this will be weighed against this decision as far as effort to benefit

#### Why

- Supporting multiple versions of PostgreSQL has _thus far_ been fairly straightforward by adhering to only query support available in the _oldest_ version of supported PostgreSQL
- By doing this, we only have one main code base, instead of many fractured versions which all employ the latest/greatest system functions/methods/tables/information schemas available
- By using 8.4.22, supporting [Redshift](https://github.com/datamill-co/target-redshift) is made simpler
  - Redshift was originally split from [PostgreSQL 8.0.2](https://docs.aws.amazon.com/redshift/latest/dg/c_redshift-and-postgres-sql.html)
  - At some point, a _lot_ of work was done by AWS to make Redshift a "simple fork" of PostgreSQL 8.4
- We do not _support_ PostgreSQL 8.4 simply because PostgreSQL does not support it anymore
  - Our _only_ benefit to making 8.4 query language our target is Redshift
  - When a new supported version of PostgreSQL comes along, and we undertake the effort to support it herein, if supporting it is simpler to do by breaking 8.4, we will move the necessary logic to [target-redshift](https://github.com/datamill-co/target-redshift)

## Suggested Musical Pairing

https://soundcloud.com/bibio/night-falls?in=bibio/sets/the-serious-ep