### PR TITLE
Refactor: Remove SQL notions from json_schema, embed code where it's …

### DIFF
--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -260,67 +260,6 @@ def validation_errors(schema):
     return errors
 
 
-def from_sql(sql_type, nullable):
-    _format = None
-    if sql_type == 'timestamp with time zone':
-        json_type = 'string'
-        _format = 'date-time'
-    elif sql_type == 'bigint':
-        json_type = 'integer'
-    elif sql_type == 'double precision':
-        json_type = 'number'
-    elif sql_type == 'boolean':
-        json_type = 'boolean'
-    elif sql_type == 'text':
-        json_type = 'string'
-    else:
-        raise JSONSchemaError('Unsupported type `{}` in existing target table'.format(sql_type))
-
-    json_type = [json_type]
-    if nullable:
-        json_type.append(NULL)
-
-    ret_json_schema = {'type': json_type}
-    if _format:
-        ret_json_schema['format'] = _format
-
-    return ret_json_schema
-
-
-def to_sql(schema):
-    _type = get_type(schema)
-    not_null = True
-    ln = len(_type)
-    if ln == 1:
-        _type = _type[0]
-    if ln == 2 and NULL in _type:
-        not_null = False
-        if _type.index(NULL) == 0:
-            _type = _type[1]
-        else:
-            _type = _type[0]
-    elif ln > 2:
-        raise JSONSchemaError('Multiple types per column not supported')
-
-    sql_type = 'text'
-
-    if 'format' in schema and \
-            schema['format'] == 'date-time' and \
-            _type == 'string':
-        sql_type = 'timestamp with time zone'
-    elif _type == 'boolean':
-        sql_type = 'boolean'
-    elif _type == 'integer':
-        sql_type = 'bigint'
-    elif _type == 'number':
-        sql_type = 'double precision'
-
-    if not_null:
-        sql_type += ' NOT NULL'
-
-    return sql_type
-
-
 _shorthand_mapping = {
     NULL: '',
     'string': 's',
@@ -346,5 +285,5 @@ def _type_shorthand(type_s):
     return _shorthand_mapping[type_s]
 
 
-def sql_shorthand(schema):
+def shorthand(schema):
     return _type_shorthand(get_type(schema))

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -531,6 +531,6 @@ def test_make_nullable():
 
 
 def test_sql_shorthand():
-    assert 'b' == json_schema.sql_shorthand({'type': 'boolean'})
-    assert 'b' == json_schema.sql_shorthand({'type': ['null', 'boolean']})
-    assert 's' == json_schema.sql_shorthand({'type': ['null', 'string']})
+    assert 'b' == json_schema.shorthand({'type': 'boolean'})
+    assert 'b' == json_schema.shorthand({'type': ['null', 'boolean']})
+    assert 's' == json_schema.shorthand({'type': ['null', 'string']})


### PR DESCRIPTION
# Motivation

In splitting out Redshift, there's some differing logic in Redshift around maximum length of a column. Since Redshift does _not_ have `TEXT` column types, we'll need to be able to override this in https://github.com/datamill-co/target-redshift.

Before cutting a new version of `target-postgres`, I wanted to get this change in place, since it'll effectively render `target-redshift` dead in the water till it happens.

Additionally, the `json_schema` module is mainly helper functions for dealing with `JSONSchema`. It doesn't _need_ to know _anything_ about SQL.

## Suggested Musical Pairing

