### PR TITLE
Fix/datetime split columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.1.3
+
+- **SCHEMA_VERSION: 1**
+  - [LINK](https://github.com/datamill-co/target-postgres/pull/89)
+  - Initialized a new field in remote table schemas `schema_version`
+  - A migration in `PostgresTarget` handles updating this
+- **BUG FIX:** A bug was identified in 0.1.2 with column type splitting.
+  - [LINK](https://github.com/datamill-co/target-postgres/pull/89)
+  - A schema with a field of type `string` is persisted to remote
+    - Later, the same field is of type `date-time`
+      - The values for this field will _not_ be placed under a new column, but rather under the original `string` column
+  - A schema with a field of type `date-time` is persisted to remote
+    - Later, the same field is of type `string`
+      - The original `date-time` column will be made `nullable`
+      - The values for this field will fail to persist

--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -18,7 +18,10 @@ def to_table_batches(schema, key_properties, records):
     :param key_properties: [string, ...]
     :param records: [{...}, ...]
     :return: [{'streamed_schema': TABLE_SCHEMA(local),
-               'records': [{...}, ...]
+               'records': [{(path_0, path_1, ...):
+                            (_json_schema_string_type, value), ...},
+                            ...]},
+              ...]
     """
     table_schemas = _get_streamed_table_schemas(schema,
                                                 key_properties)
@@ -184,7 +187,7 @@ def _get_streamed_table_records(key_properties, records):
 
     :param key_properties: [string, ...]
     :param records: [{...}, ...]
-    :return: {TableName string: [{...}, ...],
+    :return: {TableName string: [{(path_0, path_1, ...): (_json_schema_string_type, value), ...}, ...],
               ...}
     """
 

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -59,13 +59,22 @@ def get_type(schema):
 
 def simple_type(schema):
     """
-    Given a JSON Schema dict, extracts the simplified schema
+    Given a JSON Schema dict, extracts the simplified schema, ie, a schema which can only represent
+    _one_ of the given types allowed (along with the Nullable modifier):
+    - OBJECT
+    - ARRAY
+    - INTEGER
+    - NUMBER
+    - BOOLEAN
+    - STRING
+    - DATE_TIME
+
     :param schema: dict, JSON Schema
     :return: dict, JSON Schema
     """
     type = get_type(schema)
 
-    if STRING in type and 'format' in schema and schema['format'] == DATE_TIME_FORMAT:
+    if is_datetime(schema):
         return {'type': type,
                 'format': DATE_TIME_FORMAT}
 
@@ -164,7 +173,7 @@ def is_datetime(schema):
     :return: Boolean
     """
 
-    return 'format' in simple_type(schema)
+    return STRING in get_type(schema) and schema.get('format') == DATE_TIME_FORMAT
 
 
 def make_nullable(schema):

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -266,6 +266,7 @@ _shorthand_mapping = {
     'number': 'f',
     'integer': 'i',
     'boolean': 'b',
+    'date-time': 't'
 }
 
 
@@ -286,4 +287,10 @@ def _type_shorthand(type_s):
 
 
 def shorthand(schema):
-    return _type_shorthand(get_type(schema))
+    _type = deepcopy(get_type(schema))
+
+    if 'format' in schema and 'date-time' == schema['format'] and STRING in _type:
+        _type.remove(STRING)
+        _type.append('date-time')
+
+    return _type_shorthand(_type)

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -11,6 +11,7 @@ INTEGER = 'integer'
 NUMBER = 'number'
 BOOLEAN = 'boolean'
 STRING = 'string'
+DATE_TIME_FORMAT = 'date-time'
 
 _PYTHON_TYPE_TO_JSON_SCHEMA = {
     int: INTEGER,
@@ -54,6 +55,21 @@ def get_type(schema):
         return [type]
 
     return type
+
+
+def simple_type(schema):
+    """
+    Given a JSON Schema dict, extracts the simplified schema
+    :param schema: dict, JSON Schema
+    :return: dict, JSON Schema
+    """
+    type = get_type(schema)
+
+    if STRING in type and 'format' in schema and schema['format'] == DATE_TIME_FORMAT:
+        return {'type': type,
+                'format': DATE_TIME_FORMAT}
+
+    return {'type': type}
 
 
 def _get_ref(schema, paths):
@@ -139,6 +155,16 @@ def is_literal(schema):
     """
 
     return not {STRING, INTEGER, NUMBER, BOOLEAN}.isdisjoint(set(get_type(schema)))
+
+
+def is_datetime(schema):
+    """
+    Given a JSON Schema compatible dict, returns True when schema's type allows being a date-time
+    :param schema: dict, JSON Schema
+    :return: Boolean
+    """
+
+    return 'format' in simple_type(schema)
 
 
 def make_nullable(schema):

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -219,7 +219,8 @@ class PostgresTarget(SQLInterface):
 
         cur.execute(sql.SQL('{} ();').format(create_table_sql))
 
-        self._set_table_metadata(cur, name, {'version': metadata.get('version', None)})
+        self._set_table_metadata(cur, name, {'version': metadata.get('version', None),
+                                             'schema_version': metadata['schema_version']})
 
     def add_table_mapping(self, cur, from_path, metadata):
         root_table = from_path[0]

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -520,8 +520,13 @@ class PostgresTarget(SQLInterface):
         if not 'mappings' in metadata:
             metadata['mappings'] = {}
 
-        metadata['mappings'][to_name] = {'type': json_schema.get_type(mapped_schema),
-                                         'from': from_path}
+        mapping = {'type': json_schema.get_type(mapped_schema),
+                   'from': from_path}
+
+        if 't' == json_schema.shorthand(mapped_schema):
+            mapping['format'] = 'date-time'
+
+        metadata['mappings'][to_name] = mapping
 
         self._set_table_metadata(cur, table_name, metadata)
 

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -327,7 +327,10 @@ class SQLInterface:
         """
         table_path = schema['path']
 
-        table_name = self.add_table_mapping(connection, table_path, metadata)
+        _metadata = deepcopy(metadata)
+        _metadata['schema_version'] = CURRENT_SCHEMA_VERSION
+
+        table_name = self.add_table_mapping(connection, table_path, _metadata)
 
         existing_schema = self._get_table_schema(connection, table_path, table_name)
 

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -336,7 +336,7 @@ class SQLInterface:
                 if make_nullable:
                     single_type_columns.append((column_path, json_schema.make_nullable(single_type_column_schema)))
                 else:
-                    single_type_columns.append((column_path, single_type_column_schema))
+                    single_type_columns.append((column_path, deepcopy(single_type_column_schema)))
 
         ## Process new columns against existing
         raw_mappings = existing_schema.get('mappings', {})

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -344,7 +344,10 @@ class SQLInterface:
         mappings = []
 
         for to, m in raw_mappings.items():
-            mappings.append({'from': tuple(m['from']), 'to': to, 'type': m['type']})
+            mapping = json_schema.simple_type(m)
+            mapping['from'] = tuple(m['from'])
+            mapping['to'] = to
+            mappings.append(mapping)
 
         table_empty = self.is_table_empty(connection, table_name)
 
@@ -371,10 +374,11 @@ class SQLInterface:
                                         column_path,
                                         canonicalized_column_name,
                                         column_schema)
-                mappings.append(
-                    {'from': column_path,
-                     'to': canonicalized_column_name,
-                     'type': json_schema.get_type(column_schema)})
+
+                mapping = json_schema.simple_type(column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
 
                 continue
 
@@ -410,9 +414,11 @@ class SQLInterface:
 
                 mappings = [m for m in mappings if not (m['from'] == column_path and json_schema.shorthand(
                     m) == json_schema.shorthand(column_schema))]
-                mappings.append({'from': column_path,
-                                 'to': canonicalized_column_name,
-                                 'type': json_schema.get_type(nullable_column_schema)})
+
+                mapping = json_schema.simple_type(nullable_column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
 
                 continue
 
@@ -430,16 +436,20 @@ class SQLInterface:
 
                 ## Update existing properties
                 mappings = [m for m in mappings if m['from'] != column_path]
-                mappings.append({'from': column_path,
-                                 'to': canonicalized_column_name,
-                                 'type': json_schema.get_type(nullable_column_schema)})
+
+                mapping = json_schema.simple_type(nullable_column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
 
                 existing_column_new_normalized_name = self._canonicalize_column_identifier(column_path,
                                                                                            existing_mapping,
                                                                                            mappings)
-                mappings.append({'from': column_path,
-                                 'to': existing_column_new_normalized_name,
-                                 'type': json_schema.get_type(json_schema.make_nullable(existing_mapping))})
+
+                mapping = json_schema.simple_type(json_schema.make_nullable(existing_mapping))
+                mapping['from'] = column_path
+                mapping['to'] = existing_column_new_normalized_name
+                mappings.append(mapping)
 
                 ## Add new columns
                 ### NOTE: all migrated columns will be nullable and remain that way
@@ -492,9 +502,10 @@ class SQLInterface:
                                 canonicalized_column_name,
                                 nullable_column_schema)
 
-                mappings.append({'from': column_path,
-                                 'to': canonicalized_column_name,
-                                 'type': json_schema.get_type(nullable_column_schema)})
+                mapping = json_schema.simple_type(nullable_column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
 
             ## UNKNOWN
             else:
@@ -507,29 +518,29 @@ class SQLInterface:
 
         return self.get_table_schema(connection, table_path, table_name)
 
-    def _serialize_table_record_field_name(self, remote_schema, streamed_schema, path, json_schema_type):
+    def _serialize_table_record_field_name(self, remote_schema, streamed_schema, path, value_json_schema):
         """
         Returns the appropriate remote field (column) name for `field`.
 
         :param remote_schema: TABLE_SCHEMA(remote)
         :param streamed_schema: TABLE_SCHEMA(local)
         :param path: (string, ...)
-        :value_json_schema_type: string
+        :value_json_schema: dict, JSON Schema
         :return: string
         """
 
-        json_schema_type = json_schema_type or json_schema.get_type(streamed_schema['schema']['properties'][path])
+        simple_json_schema = json_schema.simple_type(value_json_schema)
 
         mapping = self._get_mapping(remote_schema,
                                     path,
-                                    {'type': json_schema_type})
+                                    simple_json_schema)
 
         if not mapping is None:
             return mapping
 
         ## Numbers are valid as `float` OR `int`
         ##  ie, 123.0 and 456 are valid 'number's
-        if json_schema.INTEGER in json_schema_type:
+        if json_schema.INTEGER in json_schema.get_type(simple_json_schema):
             mapping = self._get_mapping(remote_schema,
                                         path,
                                         {'type': json_schema.NUMBER})
@@ -581,12 +592,12 @@ class SQLInterface:
 
         :param remote_schema: TABLE_SCHEMA(remote)
         :param streamed_schema: TABLE_SCHEMA(local)
-        :param records: [{(path_0, path_1, ...): (_json_schema_type, value), ...}, ...]
+        :param records: [{(path_0, path_1, ...): (_json_schema_string_type, value), ...}, ...]
         :return: [{...}, ...]
         """
 
         datetime_paths = [k for k, v in streamed_schema['schema']['properties'].items()
-                          if v.get('format') == 'date-time']
+                          if json_schema.is_datetime(v)]
 
         default_paths = {k: v.get('default') for k, v in streamed_schema['schema']['properties'].items()
                          if v.get('default') is not None}
@@ -605,26 +616,34 @@ class SQLInterface:
             row = deepcopy(default_row)
 
             for path in paths:
-                json_schema_type, value = record.get(path, (None, None))
+                json_schema_string_type, value = record.get(path, (None, None))
 
                 ## Serialize fields which are not present but have default values set
                 if path in default_paths \
                         and value is None:
                     value = default_paths[path]
-                    json_schema_type = json_schema.python_type(value)
+                    json_schema_string_type = json_schema.python_type(value)
 
                 ## Serialize datetime to compatible format
                 if path in datetime_paths \
-                        and json_schema_type == json_schema.STRING \
+                        and json_schema_string_type == json_schema.STRING \
                         and value is not None:
                     value = self.serialize_table_record_datetime_value(remote_schema, streamed_schema, path,
                                                                        value)
+                    value_json_schema = {'type': json_schema.STRING,
+                                         'format': json_schema.DATE_TIME_FORMAT}
+                elif json_schema_string_type:
+                    value_json_schema = {'type': json_schema_string_type}
+                else:
+                    value_json_schema = json_schema.simple_type(streamed_schema['schema']['properties'][path])
 
                 ## Serialize NULL default value
                 value = self.serialize_table_record_null_value(remote_schema, streamed_schema, path, value)
 
-                field_name = self._serialize_table_record_field_name(remote_schema, streamed_schema, path,
-                                                                     json_schema_type)
+                field_name = self._serialize_table_record_field_name(remote_schema,
+                                                                     streamed_schema,
+                                                                     path,
+                                                                     value_json_schema)
 
                 if field_name in remote_fields \
                         and (not field_name in row

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,8 +8,6 @@ import arrow
 from faker import Faker
 from chance import chance
 
-from target_postgres.singer_stream import SINGER_SEQUENCE
-
 CONFIG = {
     'postgres_host': os.environ['POSTGRES_HOST'],
     'postgres_database': os.environ['POSTGRES_DATABASE'],

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5,6 +5,7 @@ import pytest
 from target_postgres import json_schema
 from fixtures import CATS_SCHEMA
 
+
 def test_python_type():
     assert json_schema.python_type(None) \
            == json_schema.NULL
@@ -13,7 +14,7 @@ def test_python_type():
     assert json_schema.python_type(True) \
            == json_schema.BOOLEAN
     assert json_schema.python_type(123) \
-    == json_schema.INTEGER
+           == json_schema.INTEGER
     assert json_schema.python_type(0) \
            == json_schema.INTEGER
     assert json_schema.python_type(-1234567890) \
@@ -30,6 +31,7 @@ def test_python_type():
            == json_schema.STRING
     assert json_schema.python_type('world') \
            == json_schema.STRING
+
 
 def test_is_object():
     assert json_schema.is_object({'type': ['object']})
@@ -534,3 +536,7 @@ def test_sql_shorthand():
     assert 'b' == json_schema.shorthand({'type': 'boolean'})
     assert 'b' == json_schema.shorthand({'type': ['null', 'boolean']})
     assert 's' == json_schema.shorthand({'type': ['null', 'string']})
+    assert 't' == json_schema.shorthand({'type': ['null', 'string'],
+                                         'format': 'date-time'})
+    assert 't' == json_schema.shorthand({'type': 'string',
+                                         'format': 'date-time'})

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -61,6 +61,7 @@ def test_is_datetime():
     assert not json_schema.is_datetime({'type': ['integer', 'null']})
     assert not json_schema.is_datetime({'type': ['string']})
     assert json_schema.is_datetime({'type': 'string', 'format': 'date-time'})
+    assert not json_schema.is_datetime({'type': 'string', 'format': 'email'})
     assert not json_schema.is_datetime({'type': ['string', 'null']})
 
 

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -57,6 +57,13 @@ def test_is_literal():
     assert not json_schema.is_literal({})
 
 
+def test_is_datetime():
+    assert not json_schema.is_datetime({'type': ['integer', 'null']})
+    assert not json_schema.is_datetime({'type': ['string']})
+    assert json_schema.is_datetime({'type': 'string', 'format': 'date-time'})
+    assert not json_schema.is_datetime({'type': ['string', 'null']})
+
+
 def test_complex_objects__logical_statements():
     every_type = {
         'type': ['null', 'integer', 'number', 'boolean', 'string', 'array', 'object'],
@@ -540,3 +547,13 @@ def test_sql_shorthand():
                                          'format': 'date-time'})
     assert 't' == json_schema.shorthand({'type': 'string',
                                          'format': 'date-time'})
+
+
+def test_simple_type():
+    assert {'type': ['integer', 'null']} \
+           == json_schema.simple_type({'type': ['integer', 'null']})
+    assert {'type': ['string'], 'format': 'date-time'} \
+           == json_schema.simple_type({'type': 'string',
+                                       'format': 'date-time',
+                                       'something': 1,
+                                       'extra': 2})

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -163,7 +163,7 @@ def test_loading__invalid__default_null_value__non_nullable_column(db_cleanup):
         main(CONFIG, input_stream=NullDefaultCatStream(20))
 
 
-def test_loading__invalid_schema_version(db_cleanup):
+def test_loading__schema_version_0_gets_migrated_to_1(db_cleanup):
     main(CONFIG, input_stream=CatStream(100))
 
     with psycopg2.connect(**TEST_DB) as conn:
@@ -173,8 +173,7 @@ def test_loading__invalid_schema_version(db_cleanup):
             metadata.pop('schema_version')
             target._set_table_metadata(cur, 'cats', metadata)
 
-    with pytest.raises(postgres.PostgresError, match=r'.*Expected version.*'):
-        main(CONFIG, input_stream=CatStream(100))
+    main(CONFIG, input_stream=CatStream(100))
 
 
 def test_loading__simple(db_cleanup):

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1124,6 +1124,33 @@ def test_upsert(db_cleanup):
         with conn.cursor() as cur:
             cur.execute(get_count_sql('cats'))
             assert cur.fetchone()[0] == 100
+            assert_columns_equal(cur,
+                                 'cats',
+                                 {
+                                     ('_sdc_batched_at', 'timestamp with time zone', 'YES'),
+                                     ('_sdc_received_at', 'timestamp with time zone', 'YES'),
+                                     ('_sdc_sequence', 'bigint', 'YES'),
+                                     ('_sdc_table_version', 'bigint', 'YES'),
+                                     ('adoption__adopted_on', 'timestamp with time zone', 'YES'),
+                                     ('adoption__was_foster', 'boolean', 'YES'),
+                                     ('age', 'bigint', 'YES'),
+                                     ('id', 'bigint', 'NO'),
+                                     ('name', 'text', 'NO'),
+                                     ('paw_size', 'bigint', 'NO'),
+                                     ('paw_colour', 'text', 'NO'),
+                                     ('flea_check_complete', 'boolean', 'NO'),
+                                     ('pattern', 'text', 'YES')
+                                 })
+
+            assert_columns_equal(cur,
+                                 'cats__adoption__immunizations',
+                                 {
+                                     ('_sdc_level_0_id', 'bigint', 'NO'),
+                                     ('_sdc_sequence', 'bigint', 'YES'),
+                                     ('_sdc_source_key_id', 'bigint', 'NO'),
+                                     ('date_administered', 'timestamp with time zone', 'YES'),
+                                     ('type', 'text', 'YES')
+                                 })
         assert_records(conn, stream.records, 'cats', 'id')
 
     stream = CatStream(100)
@@ -1133,6 +1160,33 @@ def test_upsert(db_cleanup):
         with conn.cursor() as cur:
             cur.execute(get_count_sql('cats'))
             assert cur.fetchone()[0] == 100
+            assert_columns_equal(cur,
+                                 'cats',
+                                 {
+                                     ('_sdc_batched_at', 'timestamp with time zone', 'YES'),
+                                     ('_sdc_received_at', 'timestamp with time zone', 'YES'),
+                                     ('_sdc_sequence', 'bigint', 'YES'),
+                                     ('_sdc_table_version', 'bigint', 'YES'),
+                                     ('adoption__adopted_on', 'timestamp with time zone', 'YES'),
+                                     ('adoption__was_foster', 'boolean', 'YES'),
+                                     ('age', 'bigint', 'YES'),
+                                     ('id', 'bigint', 'NO'),
+                                     ('name', 'text', 'NO'),
+                                     ('paw_size', 'bigint', 'NO'),
+                                     ('paw_colour', 'text', 'NO'),
+                                     ('flea_check_complete', 'boolean', 'NO'),
+                                     ('pattern', 'text', 'YES')
+                                 })
+
+            assert_columns_equal(cur,
+                                 'cats__adoption__immunizations',
+                                 {
+                                     ('_sdc_level_0_id', 'bigint', 'NO'),
+                                     ('_sdc_sequence', 'bigint', 'YES'),
+                                     ('_sdc_source_key_id', 'bigint', 'NO'),
+                                     ('date_administered', 'timestamp with time zone', 'YES'),
+                                     ('type', 'text', 'YES')
+                                 })
         assert_records(conn, stream.records, 'cats', 'id')
 
     stream = CatStream(200)
@@ -1142,6 +1196,33 @@ def test_upsert(db_cleanup):
         with conn.cursor() as cur:
             cur.execute(get_count_sql('cats'))
             assert cur.fetchone()[0] == 200
+            assert_columns_equal(cur,
+                                 'cats',
+                                 {
+                                     ('_sdc_batched_at', 'timestamp with time zone', 'YES'),
+                                     ('_sdc_received_at', 'timestamp with time zone', 'YES'),
+                                     ('_sdc_sequence', 'bigint', 'YES'),
+                                     ('_sdc_table_version', 'bigint', 'YES'),
+                                     ('adoption__adopted_on', 'timestamp with time zone', 'YES'),
+                                     ('adoption__was_foster', 'boolean', 'YES'),
+                                     ('age', 'bigint', 'YES'),
+                                     ('id', 'bigint', 'NO'),
+                                     ('name', 'text', 'NO'),
+                                     ('paw_size', 'bigint', 'NO'),
+                                     ('paw_colour', 'text', 'NO'),
+                                     ('flea_check_complete', 'boolean', 'NO'),
+                                     ('pattern', 'text', 'YES')
+                                 })
+
+            assert_columns_equal(cur,
+                                 'cats__adoption__immunizations',
+                                 {
+                                     ('_sdc_level_0_id', 'bigint', 'NO'),
+                                     ('_sdc_sequence', 'bigint', 'YES'),
+                                     ('_sdc_source_key_id', 'bigint', 'NO'),
+                                     ('date_administered', 'timestamp with time zone', 'YES'),
+                                     ('type', 'text', 'YES')
+                                 })
         assert_records(conn, stream.records, 'cats', 'id')
 
 

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -589,8 +589,10 @@ def test_loading__column_type_change__generative(db_cleanup):
             assert insert_count <= len([x for x in persisted_records if x[0] is not None])
             assert insert_count <= len([x for x in persisted_records if x[1] is not None])
             assert insert_count <= len([x for x in persisted_records if x[2] is not None])
-            assert insert_count <= len([x for x in persisted_records if x[3] is not None])
-            assert insert_count <= len([x for x in persisted_records if x[4] is not None])
+            ## Integers are valid Numbers, so sometimes a Number can be placed into an existing Integer column
+            assert (2 * insert_count) \
+                   <= len([x for x in persisted_records if x[3] is not None]) \
+                   + len([x for x in persisted_records if x[4] is not None])
             assert 0 == len(
                 [x for x in persisted_records
                  if x[0] is not None


### PR DESCRIPTION
# Motivation

If a schema is provided which has a column which is of type `string`, and then later, a new schema is provided which has the same column but of type `date-time`, we do not split the column, but rather place all values of the date-time into the string column.

Luckily, if the schema we first see is of type `date-time` then the latter one is `string`, our upload will fail and the bug will be detected. Provided that the string values we have ***ARE NOT*** _only_ values which are also able to be processed by `arrow`:

```py
>>> arrow.get('hello-world')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/arrow-0.13.0-py3.7.egg/arrow/api.py", line 22, in get
    return _factory.get(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/arrow-0.13.0-py3.7.egg/arrow/factory.py", line 174, in get
    dt = parser.DateTimeParser(locale).parse_iso(arg)
  File "/usr/local/lib/python3.7/site-packages/arrow-0.13.0-py3.7.egg/arrow/parser.py", line 119, in parse_iso
    return self._parse_multiformat(string, formats)
  File "/usr/local/lib/python3.7/site-packages/arrow-0.13.0-py3.7.egg/arrow/parser.py", line 286, in _parse_multiformat
    raise ParserError('Could not match input to any of {} on \'{}\''.format(formats, string))
arrow.parser.ParserError: Could not match input to any of ['YYYY-MM-DD', 'YYYY/MM/DD', 'YYYY.MM.DD', 'YYYY-MM', 'YYYY/MM', 'YYYY.MM', 'YYYY', 'YYYY', 'YYYY'] on 'hello-world'
```

As such, date-time and String columns collide irrevocably. The problem here is twofold:
- we have no shorthand for date-time values
- we do not store information enough to determine that a persisted column mapping is date-time vs string

## How was this found?

While working on `target-redshift`, I had not yet implemented `make_column_nullable`. This was due to forcing _all_ columns to be nullable. However, whenever a test performed an upsert, the column was _made nullable_. This is _not_ an operation inherently _allowed_ by Redshift. As such, the test would fail. It was only after digging into what was going on that I was able to track down what was happening.

## Specific Issue

1. Columns which are date-time do _not_ contain the inherent metadata in our json blobs to detect that they _are_ in fact datetimes
    - this is mitigate-able as we still have date-time information in the schema of the column itself
    - could write a simple migration to do this
1. Columns which streamed _first_ as `string` ***THEN LATER*** as `date-time` will remain `string` forever
    - ie, all date-time values will be uploaded as strings
    - this is a current, albeit incredibly specific, bug
    - we cannot _really_ help here as any migration to place data into the correct column would need to regex parese each value to see if it's able to be translated into a valid `date-time` etc.
    - even if we parse those values, they may have _actually been strings all along_
1. All columns which first streamed as `date-time` ***THEN LATER*** as `string` will presently fail hard. As such, we do not need to worry about this case since anything like this would result in no data persisted and an issue being created herein
1. Split/Collision columns where one is a `date-time` (and no strings are present etc.) will be postfixed with `__s` ***NOT*** with anything intelligible to represent it as a `date-time`...
    - the argument can probably be made many ways here that this is a bug, or a feature
    - I would vote for not touching the naming of _current_ columns, but rather make it so that all `date-time` split/collision columns going forward be postfixed with `__t`
        - not `__d` as that could be confused with `decimal` or `double`...maybe?

## Proposal

Focus on mitigating (1) from above. ie, upgrading _existing schemas_ to have date-time information in a table.

1. start placing `schema-version` (or something) into metadata for a table.
1. any tables which _do not_ have `schema-version` are assumed to be from the first iteration, and we proceed to upgrade them
    1. warn that an old table has been detected and that we're attempting to auto-upgrade
    1. upgrade all `date-time` columns to make sure that their metadata has the information necessary to distinguish them from `string`
    1. add `schema-version`

- Add in test which random/generatively checks combinations of column splits and uploads to make sure we can't have this problem in the future.

## Suggested Musical Pairing

https://soundcloud.com/connanmockasin/quadropuss-island-1?in=connanmockasin/sets/forever-dolphin-love-2