### PR TITLE
Bump: psycopg2 2.7.6 -> 2.7.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     install_requires=[
         'arrow==0.13.0',
         'jsonschema==2.6.0',
-        'psycopg2==2.7.6',
-        'psycopg2-binary==2.7.6',
+        'psycopg2==2.7.7',
+        'psycopg2-binary==2.7.7',
         'singer-python==5.4.1'
     ],
     setup_requires=[


### PR DESCRIPTION
# Motivation

While working on a pre-release for `0.1.3`, `psycopg2` released a later version. Seems like as good a time as any to bump this dependency.

## Suggested Musical Pairing

https://soundcloud.com/craftspells/after-the-moment-2