### PR TITLE
Feature/loggging of schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
     - Later, the same field is of type `string`
       - The original `date-time` column will be made `nullable`
       - The values for this field will fail to persist
+- **FEATURES:**
+  - [Added the `logging_level`](https://github.com/datamill-co/target-postgres/pull/92) config option which uses standard Python Logger Levels to configure more details about what Target-Postgres is doing
+    - Query level logging and timing
+    - Table schema changes logging and timing

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ here.
 | `invalid_records_detect` | `["boolean", "null"]`| `true` | Include `false` in your config to disable `target-postgres` from crashing on invalid records |
 | `invalid_records_threshold` | `["integer", "null"]` | `0` | Include a positive value `n` in your config to allow for `target-postgres` to encounter at most `n` invalid records per stream before giving up. |
 | `disable_collection` | `["string", "null"]` | `false` | Include `true` in your config to disable [Singer Usage Logging](#usage-logging).
+| `logging_level` | `["string", "null"]` | `"INFO"` | The level for logging. Set to `DEBUG` to get things like queries executed, timing of those queries, etc. See [Python's Logger Levels](https://docs.python.org/3/library/logging.html#levels) for information about valid values.
 
 ### Supported Versions
 

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -1,15 +1,17 @@
 from singer import utils
 import psycopg2
 
-from target_postgres.postgres import PostgresTarget
+from target_postgres.postgres import MillisLoggingConnection, PostgresTarget
 from target_postgres import target_tools
 
 REQUIRED_CONFIG_KEYS = [
     'postgres_database'
 ]
 
+
 def main(config, input_stream=None):
     with psycopg2.connect(
+            connection_factory=MillisLoggingConnection,
             host=config.get('postgres_host', 'localhost'),
             port=config.get('postgres_port', 5432),
             dbname=config.get('postgres_database'),
@@ -18,12 +20,14 @@ def main(config, input_stream=None):
     ) as connection:
         postgres_target = PostgresTarget(
             connection,
-            postgres_schema=config.get('postgres_schema', 'public'))
+            postgres_schema=config.get('postgres_schema', 'public'),
+            logging_level=config.get('logging_level'))
 
         if input_stream:
             target_tools.stream_to_target(input_stream, postgres_target, config=config)
         else:
             target_tools.main(postgres_target)
+
 
 def cli():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -1,12 +1,15 @@
 from copy import deepcopy
-import io
-import re
 import csv
-import uuid
+import io
 import json
+import logging
+import re
+import time
+import uuid
 
 import arrow
 from psycopg2 import sql
+from psycopg2.extras import LoggingConnection, LoggingCursor
 
 from target_postgres import json_schema
 from target_postgres.sql_base import SEPARATOR, SQLInterface
@@ -40,6 +43,36 @@ def _update_schema_0_to_1(table_schema):
     return remote_schema
 
 
+class _MillisLoggingCursor(LoggingCursor):
+    """
+    An implementation of LoggingCursor which tracks duration of queries.
+    """
+
+    def execute(self, query, vars=None):
+        self.timestamp = time.time()
+        return super(_MillisLoggingCursor, self).execute(query, vars)
+
+    def callproc(self, procname, vars=None):
+        self.timestamp = time.time()
+        return super(_MillisLoggingCursor, self).callproc(procname, vars)
+
+
+class MillisLoggingConnection(LoggingConnection):
+    """
+    An implementation of LoggingConnection which tracks duration of queries.
+    """
+
+    def filter(self, msg, curs):
+        return "{} millis spent executing: {}".format(
+            int((time.time() - curs.timestamp) * 1000),
+            msg
+        )
+
+    def cursor(self, *args, **kwargs):
+        kwargs.setdefault('cursor_factory', _MillisLoggingCursor)
+        return LoggingConnection.cursor(self, *args, **kwargs)
+
+
 class PostgresError(Exception):
     """
     Raise this when there is an error with regards to Postgres streaming
@@ -60,10 +93,20 @@ class PostgresTarget(SQLInterface):
     # TODO: Figure out way to `SELECT` value from commands
     IDENTIFIER_FIELD_LENGTH = 63
 
-    def __init__(self, connection, *args, postgres_schema='public', **kwargs):
+    def __init__(self, connection, *args, postgres_schema='public', logging_level=None, **kwargs):
         self.LOGGER.info(
             'PostgresTarget created with established connection: `{}`, PostgreSQL schema: `{}`'.format(connection.dsn,
                                                                                                        postgres_schema))
+
+        if logging_level:
+            level = logging.getLevelName(logging_level)
+            self.LOGGER.setLevel(level)
+
+        try:
+            connection.initialize(self.LOGGER)
+            self.LOGGER.debug('PostgresTarget set to log all queries.')
+        except AttributeError:
+            self.LOGGER.debug('PostgresTarget disabling logging all queries.')
 
         self.conn = connection
         self.postgres_schema = postgres_schema

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -474,7 +474,8 @@ class PostgresTarget(SQLInterface):
         target_schema['path'] = (target_table_name,)
         self.upsert_table_helper(cur,
                                  target_schema,
-                                 {'version': remote_schema['version']})
+                                 {'version': remote_schema['version']},
+                                 log_schema_changes=False)
 
         ## Make streamable CSV records
         csv_headers = list(remote_schema['schema']['properties'].keys())

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -49,11 +49,11 @@ class _MillisLoggingCursor(LoggingCursor):
     """
 
     def execute(self, query, vars=None):
-        self.timestamp = time.time()
+        self.timestamp = time.monotonic()
         return super(_MillisLoggingCursor, self).execute(query, vars)
 
     def callproc(self, procname, vars=None):
-        self.timestamp = time.time()
+        self.timestamp = time.monotonic()
         return super(_MillisLoggingCursor, self).callproc(procname, vars)
 
 
@@ -63,8 +63,8 @@ class MillisLoggingConnection(LoggingConnection):
     """
 
     def filter(self, msg, curs):
-        return "{} millis spent executing: {}".format(
-            int((time.time() - curs.timestamp) * 1000),
+        return "MillisLoggingConnection: {} millis spent executing: {}".format(
+            int((time.monotonic() - curs.timestamp) * 1000),
             msg
         )
 

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -25,7 +25,7 @@ CURRENT_SCHEMA_VERSION = 1
 
 
 def _duration_millis(start):
-    return int((time.time() - start) * 1000)
+    return int((time.monotonic() - start) * 1000)
 
 
 def _mapping_name(field, schema):
@@ -729,7 +729,7 @@ class SQLInterface:
         :return: {'records_persisted': int,
                   'rows_persisted': int}
         """
-        batch__timing_start = time.time()
+        batch__timing_start = time.monotonic()
 
         self.LOGGER.info('Writing batch with {} records for `{}` with `key_properties`: `{}`'.format(
             len(records),
@@ -741,7 +741,7 @@ class SQLInterface:
         for table_batch in denest.to_table_batches(schema, key_properties, records):
             table_batch['streamed_schema']['path'] = (root_table_name,) + table_batch['streamed_schema']['path']
 
-            table_batch__schema__timing_start = time.time()
+            table_batch__schema__timing_start = time.monotonic()
 
             self.LOGGER.info('Writing table batch schema for `{}`'.format(
                 table_batch['streamed_schema']['path']
@@ -756,7 +756,7 @@ class SQLInterface:
                 table_batch['streamed_schema']['path']
             ))
 
-            table_batch__records__timing_start = time.time()
+            table_batch__records__timing_start = time.monotonic()
 
             self.LOGGER.info('Writing table batch with {} rows for `{}`'.format(
                 len(table_batch['records']),

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -13,7 +13,7 @@
 #
 
 from copy import deepcopy
-import datetime
+import time
 
 import singer
 
@@ -25,7 +25,7 @@ CURRENT_SCHEMA_VERSION = 1
 
 
 def _duration_millis(start):
-    return (datetime.datetime.now() - start).total_seconds() * 1000
+    return int((time.time() - start) * 1000)
 
 
 def _mapping_name(field, schema):
@@ -704,7 +704,7 @@ class SQLInterface:
         :return: {'records_persisted': int,
                   'rows_persisted': int}
         """
-        batch__timing_start = datetime.datetime.now()
+        batch__timing_start = time.time()
 
         self.LOGGER.info('Writing batch with {} records for `{}` with `key_properties`: `{}`'.format(
             len(records),
@@ -716,7 +716,7 @@ class SQLInterface:
         for table_batch in denest.to_table_batches(schema, key_properties, records):
             table_batch['streamed_schema']['path'] = (root_table_name,) + table_batch['streamed_schema']['path']
 
-            table_batch__schema__timing_start = datetime.datetime.now()
+            table_batch__schema__timing_start = time.time()
 
             self.LOGGER.info('Writing table batch schema for `{}`'.format(
                 table_batch['streamed_schema']['path']
@@ -731,7 +731,7 @@ class SQLInterface:
                 table_batch['streamed_schema']['path']
             ))
 
-            table_batch__records__timing_start = datetime.datetime.now()
+            table_batch__records__timing_start = time.time()
 
             self.LOGGER.info('Writing table batch with {} rows for `{}`'.format(
                 len(table_batch['records']),

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,7 +12,8 @@ CONFIG = {
     'postgres_host': os.environ['POSTGRES_HOST'],
     'postgres_database': os.environ['POSTGRES_DATABASE'],
     'postgres_username': os.environ['POSTGRES_USERNAME'],
-    'disable_collection': True
+    'disable_collection': True,
+    'logging_level': 'DEBUG'
 }
 
 TEST_DB = {


### PR DESCRIPTION
# Motivation

Issues posted by users of this codebase sometimes have a lack of usable logs present. Additionally, when testing, or debugging in production, more fine grained information can be quite useful.

## Notes

This is all opt-in-enabled by setting the new config option: `logging_level`, to `DEBUG` or lower.

This pr adds special logging with durations for:

### `sql_base.upsert_table_helper`

Each decision which modifies the table in some manner is logged:

```
INFO Table Schema Change [`root`.`('id',)`:`id`] New column (took 1 millis)
INFO Table Schema Change [`root`.`('changing_literal_type',)`:`changing_literal_type`] New column (took 1 millis)
INFO Table Schema Change [`root`.`('_sdc_received_at',)`:`_sdc_received_at`] New column (took 1 millis)
INFO Table Schema Change [`root`.`('_sdc_sequence',)`:`_sdc_sequence`] New column (took 1 millis)
INFO Table Schema Change [`root`.`('_sdc_table_version',)`:`_sdc_table_version`] New column (took 2 millis)
INFO Table Schema Change [`root`.`('_sdc_batched_at',)`:`_sdc_batched_at`] New column (took 2 millis)
INFO Table Schema Change [`root`.`('changing_literal_type',)`:`changing_literal_type__i`] Splitting changing_literal_type into changing_literal_type__f and changing_literal_type__i. New column matches existing column path, but the types are incompatible. (took 6 millis)
INFO Table Schema Change [`root`.`('changing_literal_type',)`:`changing_literal_type__b`] Adding new column to split column ('changing_literal_type',). New column matches existing column's path, but no types were compatible. (took 1 millis)
```

```
INFO Table Schema Change [`cats`.`('id',)`:`id`] New column (took 2 millis)
INFO Table Schema Change [`cats`.`('name',)`:`name`] New column (took 6 millis)
INFO Table Schema Change [`cats`.`('name',)`:`name`] Made existing column nullable. New column is nullable, existing column is not (took 3 millis)
```

### `psycopg2.connection`/`psycopg2.cursor` queries

Every query run will output logs similar to:

```
extras.py                  422 DEBUG    0 millis spent executing: b'ALTER TABLE "public"."cats" ADD COLUMN "age" bigint;'
extras.py                  422 DEBUG    1 millis spent executing: b"\n            SELECT EXISTS (\n                SELECT 1 FROM pg_tables\n                WHERE schemaname = 'public' AND\n                      tablename = 'cats');"
extras.py                  422 DEBUG    0 millis spent executing: b'SELECT description FROM pg_description WHERE objoid = \'"public"."cats"\'::regclass;'
extras.py                  422 DEBUG    0 millis spent executing: b'COMMENT ON TABLE "public"."cats" IS \'{"version": null, "schema_version": 1, "table_mappings": [{"type": "TABLE", "from": ["cats"], "to": "cats"}], "key_properties": ["id"], "mappings": {"id": {"type": ["integer"], "from": ["id"]}, "name": {"type": ["string"], "from": ["name"]}, "paw_size": {"type": ["integer"], "from": ["paw_size"]}, "paw_colour": {"type": ["string"], "from": ["paw_colour"]}, "flea_check_complete": {"type": ["boolean"], "from": ["flea_check_complete"]}, "pattern": {"type": ["string", "null"], "from": ["pattern"]}, "age": {"type": ["integer", "null"], "from": ["age"]}}}\';'
```

## Suggested Musical Pairing

Windows creeking from the cold