### PR TITLE
Fix/key properties canonicalized

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -139,7 +139,9 @@ class PostgresTarget(SQLInterface):
                             ))
 
                     for key_property in stream_buffer.key_properties:
-                        if self.json_schema_to_sql_type(current_table_schema['schema']['properties'][key_property]) \
+                        canonicalized_key, remote_column_schema = self.fetch_column_from_path((key_property,),
+                                                                                              current_table_schema)
+                        if self.json_schema_to_sql_type(remote_column_schema) \
                                 != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
                             raise PostgresError(
                                 ('`key_properties` type change detected for "{}". ' +
@@ -458,9 +460,12 @@ class PostgresTarget(SQLInterface):
         pattern = re.compile(SINGER_LEVEL.format('[0-9]+'))
         subkeys = list(filter(lambda header: re.match(pattern, header) is not None, columns))
 
+        canonicalized_key_properties = [self.fetch_column_from_path((key_property,), remote_schema)[0]
+                                        for key_property in remote_schema['key_properties']]
+
         update_sql = self._get_update_sql(remote_schema['name'],
                                           temp_table_name,
-                                          remote_schema['key_properties'],
+                                          canonicalized_key_properties,
                                           columns,
                                           subkeys)
         cur.execute(update_sql)

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -138,18 +138,19 @@ class PostgresTarget(SQLInterface):
                                 stream_buffer.key_properties
                             ))
 
-                    for key in stream_buffer.key_properties:
-                        if self.json_schema_to_sql_type(current_table_schema['schema']['properties'][key]) \
-                                != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key]):
+                    for key_property in stream_buffer.key_properties:
+                        if self.json_schema_to_sql_type(current_table_schema['schema']['properties'][key_property]) \
+                                != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
                             raise PostgresError(
                                 ('`key_properties` type change detected for "{}". ' +
                                  'Existing values are: {}. ' +
                                  'Streamed values are: {}, {}, {}').format(
-                                    key,
-                                    json_schema.get_type(current_table_schema['schema']['properties'][key]),
-                                    json_schema.get_type(stream_buffer.schema['properties'][key]),
-                                    self.json_schema_to_sql_type(current_table_schema['schema']['properties'][key]),
-                                    self.json_schema_to_sql_type(stream_buffer.schema['properties'][key])
+                                    key_property,
+                                    json_schema.get_type(current_table_schema['schema']['properties'][key_property]),
+                                    json_schema.get_type(stream_buffer.schema['properties'][key_property]),
+                                    self.json_schema_to_sql_type(
+                                        current_table_schema['schema']['properties'][key_property]),
+                                    self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property])
                                 ))
 
                 root_table_name = stream_buffer.stream

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -111,6 +111,21 @@ class SQLInterface:
         """
         raise NotImplementedError('`canonicalize_identifier` not implemented.')
 
+    def fetch_column_from_path(self, path, table_schema):
+        """
+        Should only be used for paths which have been established, ie, the schema will
+        not be changing etc.
+        :param path:
+        :param table_schema:
+        :return:
+        """
+
+        for to, m in table_schema.get('mappings', {}).items():
+            if tuple(m['from']) == path:
+                return to, json_schema.simple_type(m)
+
+        raise Exception('blahbittyblah')
+
     def _canonicalize_column_identifier(self, path, schema, mappings):
         """"""
 


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/pull/94

An issue was reported with `key_properties` which end up getting canonicalized due to naming restrictions etc.

Credit to @mirelagrigoras for finding this, triaging the problem, and actually writing the majority of the code to resolve!

## Suggested Musical Pairing
Freezing wind.