### PR TITLE
Feature: init singer.metrics usage

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -114,6 +114,10 @@ class PostgresTarget(SQLInterface):
         if self.persist_empty_tables:
             self.LOGGER.debug('PostgresTarget is persisting empty tables')
 
+    def metrics_tags(self):
+        return {'database': self.conn.get_dsn_parameters().get('dbname', None),
+                'schema': self.postgres_schema}
+
     def write_batch(self, stream_buffer):
         if not self.persist_empty_tables and stream_buffer.count == 0:
             return None

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -16,6 +16,7 @@ from copy import deepcopy
 import time
 
 import singer
+import singer.metrics as metrics
 
 from target_postgres import denest
 from target_postgres import json_schema
@@ -341,250 +342,254 @@ class SQLInterface:
         :param log_schema_changes: defaults to True, set to false to disable logging of table level schema changes
         :return: TABLE_SCHEMA(remote)
         """
-        table_path = schema['path']
+        with metrics.job_timer('upsert_table_schema') as timer:
+            timer.tags['database'] = 123
+            timer.tags['schema'] = 123
 
-        _metadata = deepcopy(metadata)
-        _metadata['schema_version'] = CURRENT_SCHEMA_VERSION
+            table_path = schema['path']
 
-        table_name = self.add_table_mapping(connection, table_path, _metadata)
+            _metadata = deepcopy(metadata)
+            _metadata['schema_version'] = CURRENT_SCHEMA_VERSION
 
-        existing_schema = self._get_table_schema(connection, table_path, table_name)
+            table_name = self.add_table_mapping(connection, table_path, _metadata)
 
-        if existing_schema is None:
-            self.add_table(connection, table_name, _metadata)
             existing_schema = self._get_table_schema(connection, table_path, table_name)
 
-        self.add_key_properties(connection, table_name, schema.get('key_properties', None))
+            if existing_schema is None:
+                self.add_table(connection, table_name, _metadata)
+                existing_schema = self._get_table_schema(connection, table_path, table_name)
 
-        ## Only process columns which have single, nullable, types
-        single_type_columns = []
-        for column_name__or__path, column_schema in schema['schema']['properties'].items():
-            column_path = column_name__or__path
-            if isinstance(column_name__or__path, str):
-                column_path = (column_name__or__path,)
+            self.add_key_properties(connection, table_name, schema.get('key_properties', None))
 
-            single_type_column_schema = deepcopy(column_schema)
-            column_types = json_schema.get_type(single_type_column_schema)
-            make_nullable = json_schema.is_nullable(column_schema)
+            ## Only process columns which have single, nullable, types
+            single_type_columns = []
+            for column_name__or__path, column_schema in schema['schema']['properties'].items():
+                column_path = column_name__or__path
+                if isinstance(column_name__or__path, str):
+                    column_path = (column_name__or__path,)
 
-            for type in column_types:
-                if type == json_schema.NULL:
+                single_type_column_schema = deepcopy(column_schema)
+                column_types = json_schema.get_type(single_type_column_schema)
+                make_nullable = json_schema.is_nullable(column_schema)
+
+                for type in column_types:
+                    if type == json_schema.NULL:
+                        continue
+
+                    single_type_column_schema['type'] = [type]
+
+                    if make_nullable:
+                        single_type_columns.append((column_path, json_schema.make_nullable(single_type_column_schema)))
+                    else:
+                        single_type_columns.append((column_path, deepcopy(single_type_column_schema)))
+
+            ## Process new columns against existing
+            raw_mappings = existing_schema.get('mappings', {})
+
+            mappings = []
+
+            for to, m in raw_mappings.items():
+                mapping = json_schema.simple_type(m)
+                mapping['from'] = tuple(m['from'])
+                mapping['to'] = to
+                mappings.append(mapping)
+
+            table_empty = self.is_table_empty(connection, table_name)
+
+            for column_path, column_schema in single_type_columns:
+                upsert_table_helper__start__column = time.monotonic()
+
+                canonicalized_column_name = self._canonicalize_column_identifier(column_path, column_schema, mappings)
+                nullable_column_schema = json_schema.make_nullable(column_schema)
+
+                def log_message(msg):
+                    if log_schema_changes:
+                        self.LOGGER.info(
+                            'Table Schema Change [`{}`.`{}`:`{}`] {} (took {} millis)'.format(
+                                table_name,
+                                column_path,
+                                canonicalized_column_name,
+                                msg,
+                                _duration_millis(upsert_table_helper__start__column)))
+
+                ## NEW COLUMN
+                if not column_path in [m['from'] for m in mappings]:
+                    upsert_table_helper__column = "New column"
+                    ### NON EMPTY TABLE
+                    if not table_empty:
+                        upsert_table_helper__column += ", non empty table"
+                        self.LOGGER.warning(
+                            'NOT EMPTY: Forcing new column `{}` in table `{}` to be nullable due to table not empty.'.format(
+                                column_path,
+                                table_name))
+                        column_schema = nullable_column_schema
+
+                    self.add_column(connection,
+                                    table_name,
+                                    canonicalized_column_name,
+                                    column_schema)
+                    self.add_column_mapping(connection,
+                                            table_name,
+                                            column_path,
+                                            canonicalized_column_name,
+                                            column_schema)
+
+                    mapping = json_schema.simple_type(column_schema)
+                    mapping['from'] = column_path
+                    mapping['to'] = canonicalized_column_name
+                    mappings.append(mapping)
+
+                    log_message(upsert_table_helper__column)
+
                     continue
 
-                single_type_column_schema['type'] = [type]
+                ## EXISTING COLUMNS
+                ### SCHEMAS MATCH
+                if [True for m in mappings if
+                    m['from'] == column_path
+                    and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(column_schema)]:
+                    continue
+                ### NULLABLE SCHEMAS MATCH
+                ###  New column _is not_ nullable, existing column _is_
+                if [True for m in mappings if
+                    m['from'] == column_path
+                    and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(nullable_column_schema)]:
+                    continue
 
-                if make_nullable:
-                    single_type_columns.append((column_path, json_schema.make_nullable(single_type_column_schema)))
+                ### NULL COMPATIBILITY
+                ###  New column _is_ nullable, existing column is _not_
+                non_null_original_column = [m for m in mappings if
+                                            m['from'] == column_path and json_schema.shorthand(
+                                                m) == json_schema.shorthand(column_schema)]
+                if non_null_original_column:
+                    ## MAKE NULLABLE
+                    self.make_column_nullable(connection,
+                                              table_name,
+                                              canonicalized_column_name)
+                    self.drop_column_mapping(connection, table_name, canonicalized_column_name)
+                    self.add_column_mapping(connection,
+                                            table_name,
+                                            column_path,
+                                            canonicalized_column_name,
+                                            nullable_column_schema)
+
+                    mappings = [m for m in mappings if not (m['from'] == column_path and json_schema.shorthand(
+                        m) == json_schema.shorthand(column_schema))]
+
+                    mapping = json_schema.simple_type(nullable_column_schema)
+                    mapping['from'] = column_path
+                    mapping['to'] = canonicalized_column_name
+                    mappings.append(mapping)
+
+                    log_message("Made existing column nullable. New column is nullable, existing column is not")
+
+                    continue
+
+                ### FIRST MULTI TYPE
+                ###  New column matches existing column path, but the types are incompatible
+                duplicate_paths = [m for m in mappings if m['from'] == column_path]
+
+                if 1 == len(duplicate_paths):
+                    existing_mapping = duplicate_paths[0]
+                    existing_column_name = existing_mapping['to']
+
+                    if existing_column_name:
+                        self.drop_column_mapping(connection, table_name, existing_column_name)
+
+                    ## Update existing properties
+                    mappings = [m for m in mappings if m['from'] != column_path]
+
+                    mapping = json_schema.simple_type(nullable_column_schema)
+                    mapping['from'] = column_path
+                    mapping['to'] = canonicalized_column_name
+                    mappings.append(mapping)
+
+                    existing_column_new_normalized_name = self._canonicalize_column_identifier(column_path,
+                                                                                               existing_mapping,
+                                                                                               mappings)
+
+                    mapping = json_schema.simple_type(json_schema.make_nullable(existing_mapping))
+                    mapping['from'] = column_path
+                    mapping['to'] = existing_column_new_normalized_name
+                    mappings.append(mapping)
+
+                    ## Add new columns
+                    ### NOTE: all migrated columns will be nullable and remain that way
+
+                    #### Table Metadata
+                    self.add_column_mapping(connection,
+                                            table_name,
+                                            column_path,
+                                            existing_column_new_normalized_name,
+                                            json_schema.make_nullable(existing_mapping))
+                    self.add_column_mapping(connection,
+                                            table_name,
+                                            column_path,
+                                            canonicalized_column_name,
+                                            nullable_column_schema)
+
+                    #### Columns
+                    self.add_column(connection,
+                                    table_name,
+                                    existing_column_new_normalized_name,
+                                    json_schema.make_nullable(existing_mapping))
+
+                    self.add_column(connection,
+                                    table_name,
+                                    canonicalized_column_name,
+                                    nullable_column_schema)
+
+                    ## Migrate existing data
+                    self.migrate_column(connection,
+                                        table_name,
+                                        existing_mapping['to'],
+                                        existing_column_new_normalized_name)
+
+                    ## Drop existing column
+                    self.drop_column(connection,
+                                     table_name,
+                                     existing_mapping['to'])
+
+                    upsert_table_helper__column = "Splitting `{}` into `{}` and `{}`. New column matches existing column path, but the types are incompatible.".format(
+                        existing_column_name,
+                        existing_column_new_normalized_name,
+                        canonicalized_column_name
+                    )
+
+                ## REST MULTI TYPE
+                elif 1 < len(duplicate_paths):
+                    ## Add new column
+                    self.add_column_mapping(connection,
+                                            table_name,
+                                            column_path,
+                                            canonicalized_column_name,
+                                            nullable_column_schema)
+                    self.add_column(connection,
+                                    table_name,
+                                    canonicalized_column_name,
+                                    nullable_column_schema)
+
+                    mapping = json_schema.simple_type(nullable_column_schema)
+                    mapping['from'] = column_path
+                    mapping['to'] = canonicalized_column_name
+                    mappings.append(mapping)
+
+                    upsert_table_helper__column = "Adding new column to split column `{}`. New column matches existing column's path, but no types were compatible.".format(
+                        column_path
+                    )
+
+                ## UNKNOWN
                 else:
-                    single_type_columns.append((column_path, deepcopy(single_type_column_schema)))
-
-        ## Process new columns against existing
-        raw_mappings = existing_schema.get('mappings', {})
-
-        mappings = []
-
-        for to, m in raw_mappings.items():
-            mapping = json_schema.simple_type(m)
-            mapping['from'] = tuple(m['from'])
-            mapping['to'] = to
-            mappings.append(mapping)
-
-        table_empty = self.is_table_empty(connection, table_name)
-
-        for column_path, column_schema in single_type_columns:
-            upsert_table_helper__start__column = time.monotonic()
-
-            canonicalized_column_name = self._canonicalize_column_identifier(column_path, column_schema, mappings)
-            nullable_column_schema = json_schema.make_nullable(column_schema)
-
-            def log_message(msg):
-                if log_schema_changes:
-                    self.LOGGER.info(
-                        'Table Schema Change [`{}`.`{}`:`{}`] {} (took {} millis)'.format(
-                            table_name,
+                    raise Exception(
+                        'UNKNOWN: Cannot handle merging column `{}` (canonicalized as: `{}`) in table `{}`.'.format(
                             column_path,
                             canonicalized_column_name,
-                            msg,
-                            _duration_millis(upsert_table_helper__start__column)))
-
-            ## NEW COLUMN
-            if not column_path in [m['from'] for m in mappings]:
-                upsert_table_helper__column = "New column"
-                ### NON EMPTY TABLE
-                if not table_empty:
-                    upsert_table_helper__column += ", non empty table"
-                    self.LOGGER.warning(
-                        'NOT EMPTY: Forcing new column `{}` in table `{}` to be nullable due to table not empty.'.format(
-                            column_path,
-                            table_name))
-                    column_schema = nullable_column_schema
-
-                self.add_column(connection,
-                                table_name,
-                                canonicalized_column_name,
-                                column_schema)
-                self.add_column_mapping(connection,
-                                        table_name,
-                                        column_path,
-                                        canonicalized_column_name,
-                                        column_schema)
-
-                mapping = json_schema.simple_type(column_schema)
-                mapping['from'] = column_path
-                mapping['to'] = canonicalized_column_name
-                mappings.append(mapping)
+                            table_name
+                        ))
 
                 log_message(upsert_table_helper__column)
 
-                continue
-
-            ## EXISTING COLUMNS
-            ### SCHEMAS MATCH
-            if [True for m in mappings if
-                m['from'] == column_path
-                and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(column_schema)]:
-                continue
-            ### NULLABLE SCHEMAS MATCH
-            ###  New column _is not_ nullable, existing column _is_
-            if [True for m in mappings if
-                m['from'] == column_path
-                and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(nullable_column_schema)]:
-                continue
-
-            ### NULL COMPATIBILITY
-            ###  New column _is_ nullable, existing column is _not_
-            non_null_original_column = [m for m in mappings if
-                                        m['from'] == column_path and json_schema.shorthand(
-                                            m) == json_schema.shorthand(column_schema)]
-            if non_null_original_column:
-                ## MAKE NULLABLE
-                self.make_column_nullable(connection,
-                                          table_name,
-                                          canonicalized_column_name)
-                self.drop_column_mapping(connection, table_name, canonicalized_column_name)
-                self.add_column_mapping(connection,
-                                        table_name,
-                                        column_path,
-                                        canonicalized_column_name,
-                                        nullable_column_schema)
-
-                mappings = [m for m in mappings if not (m['from'] == column_path and json_schema.shorthand(
-                    m) == json_schema.shorthand(column_schema))]
-
-                mapping = json_schema.simple_type(nullable_column_schema)
-                mapping['from'] = column_path
-                mapping['to'] = canonicalized_column_name
-                mappings.append(mapping)
-
-                log_message("Made existing column nullable. New column is nullable, existing column is not")
-
-                continue
-
-            ### FIRST MULTI TYPE
-            ###  New column matches existing column path, but the types are incompatible
-            duplicate_paths = [m for m in mappings if m['from'] == column_path]
-
-            if 1 == len(duplicate_paths):
-                existing_mapping = duplicate_paths[0]
-                existing_column_name = existing_mapping['to']
-
-                if existing_column_name:
-                    self.drop_column_mapping(connection, table_name, existing_column_name)
-
-                ## Update existing properties
-                mappings = [m for m in mappings if m['from'] != column_path]
-
-                mapping = json_schema.simple_type(nullable_column_schema)
-                mapping['from'] = column_path
-                mapping['to'] = canonicalized_column_name
-                mappings.append(mapping)
-
-                existing_column_new_normalized_name = self._canonicalize_column_identifier(column_path,
-                                                                                           existing_mapping,
-                                                                                           mappings)
-
-                mapping = json_schema.simple_type(json_schema.make_nullable(existing_mapping))
-                mapping['from'] = column_path
-                mapping['to'] = existing_column_new_normalized_name
-                mappings.append(mapping)
-
-                ## Add new columns
-                ### NOTE: all migrated columns will be nullable and remain that way
-
-                #### Table Metadata
-                self.add_column_mapping(connection,
-                                        table_name,
-                                        column_path,
-                                        existing_column_new_normalized_name,
-                                        json_schema.make_nullable(existing_mapping))
-                self.add_column_mapping(connection,
-                                        table_name,
-                                        column_path,
-                                        canonicalized_column_name,
-                                        nullable_column_schema)
-
-                #### Columns
-                self.add_column(connection,
-                                table_name,
-                                existing_column_new_normalized_name,
-                                json_schema.make_nullable(existing_mapping))
-
-                self.add_column(connection,
-                                table_name,
-                                canonicalized_column_name,
-                                nullable_column_schema)
-
-                ## Migrate existing data
-                self.migrate_column(connection,
-                                    table_name,
-                                    existing_mapping['to'],
-                                    existing_column_new_normalized_name)
-
-                ## Drop existing column
-                self.drop_column(connection,
-                                 table_name,
-                                 existing_mapping['to'])
-
-                upsert_table_helper__column = "Splitting `{}` into `{}` and `{}`. New column matches existing column path, but the types are incompatible.".format(
-                    existing_column_name,
-                    existing_column_new_normalized_name,
-                    canonicalized_column_name
-                )
-
-            ## REST MULTI TYPE
-            elif 1 < len(duplicate_paths):
-                ## Add new column
-                self.add_column_mapping(connection,
-                                        table_name,
-                                        column_path,
-                                        canonicalized_column_name,
-                                        nullable_column_schema)
-                self.add_column(connection,
-                                table_name,
-                                canonicalized_column_name,
-                                nullable_column_schema)
-
-                mapping = json_schema.simple_type(nullable_column_schema)
-                mapping['from'] = column_path
-                mapping['to'] = canonicalized_column_name
-                mappings.append(mapping)
-
-                upsert_table_helper__column = "Adding new column to split column `{}`. New column matches existing column's path, but no types were compatible.".format(
-                    column_path
-                )
-
-            ## UNKNOWN
-            else:
-                raise Exception(
-                    'UNKNOWN: Cannot handle merging column `{}` (canonicalized as: `{}`) in table `{}`.'.format(
-                        column_path,
-                        canonicalized_column_name,
-                        table_name
-                    ))
-
-            log_message(upsert_table_helper__column)
-
-        return self._get_table_schema(connection, table_path, table_name)
+            return self._get_table_schema(connection, table_path, table_name)
 
     def _serialize_table_record_field_name(self, remote_schema, streamed_schema, path, value_json_schema):
         """
@@ -749,68 +754,60 @@ class SQLInterface:
         :return: {'records_persisted': int,
                   'rows_persisted': int}
         """
-        batch__timing_start = time.monotonic()
+        with metrics.job_timer('stream_batch') as batch_timer:
+            with metrics.record_counter(None) as batch_counter:
+                batch_timer.tags['database'] = 123
+                batch_timer.tags['schema'] = 123
+                batch_counter.tags['database'] = 123
+                batch_counter.tags['schema'] = 123
 
-        self.LOGGER.info('Writing batch with {} records for `{}` with `key_properties`: `{}`'.format(
-            len(records),
-            root_table_name,
-            key_properties
-        ))
+                batch__timing_start = time.monotonic()
 
-        rows_persisted = 0
-        for table_batch in denest.to_table_batches(schema, key_properties, records):
-            table_batch['streamed_schema']['path'] = (root_table_name,) + table_batch['streamed_schema']['path']
+                self.LOGGER.info('Writing batch with {} records for `{}` with `key_properties`: `{}`'.format(
+                    len(records),
+                    root_table_name,
+                    key_properties
+                ))
 
-            table_batch__schema__timing_start = time.monotonic()
+                for table_batch in denest.to_table_batches(schema, key_properties, records):
+                    with metrics.job_timer('stream_batch') as table_batch_timer:
+                        with metrics.record_counter(None) as table_batch_counter:
+                            table_batch_timer.tags['database'] = 123
+                            table_batch_timer.tags['schema'] = 123
+                            table_batch_counter.tags['database'] = 123
+                            table_batch_counter.tags['schema'] = 123
 
-            self.LOGGER.info('Writing table batch schema for `{}`'.format(
-                table_batch['streamed_schema']['path']
-            ))
+                            table_batch['streamed_schema']['path'] = (root_table_name,) + \
+                                                                     table_batch['streamed_schema']['path']
 
-            remote_schema = self.upsert_table_helper(connection,
-                                                     table_batch['streamed_schema'],
-                                                     metadata)
+                            self.LOGGER.info('Writing table batch schema for `{}`...'.format(
+                                table_batch['streamed_schema']['path']
+                            ))
 
-            self.LOGGER.info('Table batch schema written in {} millis for `{}`'.format(
-                _duration_millis(table_batch__schema__timing_start),
-                table_batch['streamed_schema']['path']
-            ))
+                            remote_schema = self.upsert_table_helper(connection,
+                                                                     table_batch['streamed_schema'],
+                                                                     metadata)
 
-            table_batch__records__timing_start = time.monotonic()
+                            self.LOGGER.info('Writing table batch with {} rows for `{}`...'.format(
+                                len(table_batch['records']),
+                                table_batch['streamed_schema']['path']
+                            ))
 
-            self.LOGGER.info('Writing table batch with {} rows for `{}`'.format(
-                len(table_batch['records']),
-                table_batch['streamed_schema']['path']
-            ))
+                            batch_rows_persisted = self.write_table_batch(
+                                connection,
+                                {'remote_schema': remote_schema,
+                                 'records': self._serialize_table_records(remote_schema,
+                                                                          table_batch['streamed_schema'],
+                                                                          table_batch['records'])},
+                                metadata)
 
-            batch_rows_persisted = self.write_table_batch(
-                connection,
-                {'remote_schema': remote_schema,
-                 'records': self._serialize_table_records(remote_schema,
-                                                          table_batch['streamed_schema'],
-                                                          table_batch['records'])},
-                metadata)
+                            table_batch_counter.increment(batch_rows_persisted)
+                            batch_counter.increment(batch_rows_persisted)
 
-            self.LOGGER.info('Table batch with {} rows wrote {} rows in {} millis for {}'.format(
-                len(table_batch['records']),
-                batch_rows_persisted,
-                _duration_millis(table_batch__records__timing_start),
-                table_batch['streamed_schema']['path']
-            ))
-
-            rows_persisted += batch_rows_persisted
-
-        self.LOGGER.info('Batch with {} records wrote {} rows in {} millis for `{}`'.format(
-            len(records),
-            rows_persisted,
-            _duration_millis(batch__timing_start),
-            root_table_name
-        ))
-
-        return {
-            'records_persisted': len(records),
-            'rows_persisted': rows_persisted
-        }
+                return {
+                    'records_persisted': len(records),
+                    'rows_persisted': batch_counter.value
+                }
 
     def write_batch(self, stream_buffer):
         """


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/issues/75

## Notes

Whereas the `tap`s for SQL _know_ which table they are persisting to, our `stream`s are potentially nested. For this reason, we include the following tags:

- `path`: `tuple` of `string`s representing the denested path to a given table
- `table`: optional `string` representing the remote table we are dealing with
- `schema`: `string` representing the remote schema we're dealing with
- `database`: `string` representing the remote database we're dealing with

## Testing

Output provided by the CCI tests:

```
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.013872385025024414, "tags": {"job_type": "upsert_table_schema", "path": ["stargazers"], "database": "target_postgres_test", "schema": "public", "table": "stargazers", "status": "succeeded"}}
INFO Writing table batch with 18 rows for `('stargazers',)`...
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.011026144027709961, "tags": {"job_type": "upsert_table_schema", "path": ["tmp_c85777c0_12cd_41a0_ad96_089ea9418713"], "database": "target_postgres_test", "schema": "public", "table": "tmp_c85777c0_12cd_41a0_ad96_089ea9418713", "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 18, "tags": {"count_type": "table_rows_persisted", "path": ["stargazers"], "database": "target_postgres_test", "schema": "public", "table": "stargazers"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.03966832160949707, "tags": {"job_type": "table", "path": ["stargazers"], "database": "target_postgres_test", "schema": "public", "table": "stargazers", "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 18, "tags": {"count_type": "batch_rows_persisted", "path": ["stargazers"], "database": "target_postgres_test", "schema": "public"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.041277408599853516, "tags": {"job_type": "batch", "path": ["stargazers"], "database": "target_postgres_test", "schema": "public", "status": "succeeded"}}
...
```

## Suggested Musical Pairing
https://soundcloud.com/10cc-official/art-for-arts-sake-album?in=drunken-ambassador/sets/interval