### PR TITLE
[bugfix] Fix for issue #109

### DIFF
--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -93,6 +93,7 @@ def _literal_only_schema(schema):
 
 
 def _denest_schema_helper(table_path,
+                          prop_path,
                           table_json_schema,
                           nullable,
                           top_level_schema,
@@ -102,6 +103,7 @@ def _denest_schema_helper(table_path,
     for prop, item_json_schema in table_json_schema['properties'].items():
         if json_schema.is_object(item_json_schema):
             _denest_schema_helper(table_path + (prop,),
+                                  prop_path + (prop,),
                                   item_json_schema,
                                   nullable,
                                   top_level_schema,
@@ -120,7 +122,7 @@ def _denest_schema_helper(table_path,
             if nullable and not json_schema.is_nullable(item_json_schema):
                 item_json_schema['type'].append('null')
 
-            top_level_schema[table_path + (prop,)] = _literal_only_schema(item_json_schema)
+            top_level_schema[prop_path + (prop,)] = _literal_only_schema(item_json_schema)
 
 
 def _create_subtable(table_path, table_json_schema, key_prop_schemas, subtables, level):
@@ -159,6 +161,7 @@ def _denest_schema(table_path, table_json_schema, key_prop_schemas, subtables, l
 
         if json_schema.is_object(item_json_schema):
             _denest_schema_helper(table_path + (prop,),
+                                  (prop,),
                                   item_json_schema,
                                   json_schema.is_nullable(item_json_schema),
                                   new_properties,
@@ -221,7 +224,7 @@ def _denest_subrecord(table_path,
             """
             {...}
             """
-            _denest_subrecord(table_path,
+            _denest_subrecord(table_path + (prop,),
                               prop_path + (prop,),
                               parent_record,
                               value,
@@ -234,7 +237,7 @@ def _denest_subrecord(table_path,
             """
             [...]
             """
-            _denest_records(prop_path + (prop,),
+            _denest_records(table_path + (prop,),
                             value,
                             records_map,
                             key_properties,


### PR DESCRIPTION
# Fix for issue #109 

The table_schemas and the table_records did not match for more complex and nested schemas. This is now fixed and they match. All nested data that I had trouble with before now enters the database as expected. One question remains: Is this the way we want to organize/structure the tables and naming of them? I guess we could change the records denesting instead to match the schema we had before, that should also work and that will give us a slightly different structure/naming of tables and objects.<br/>
Below you find an example of how the tables for schema and record mismatched before and how they now match for a simple example using data from the `CATS_SCHEMA` in target-postgres. Look for the `vaccination_type` especially.

### Before:
```
___table_schemas:  [{'type': 'TABLE_SCHEMA', 'path': (), 'level': None, 'key_properties': ['id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('id',): {'type': ['integer']}, ('name',): {'type': ['string']}, ('paw_size',): {'type': ['integer'], 'default': 314159}, ('paw_colour',): {'type': ['string'], 'default': ''}, ('flea_check_complete',): {'type': ['boolean'], 'default': False}, ('pattern',): {'type': ['null', 'string']}, ('age',): {'type': ['null', 'integer']}, ('adoption', 'adopted_on'): {'type': ['null', 'string'], 'format': 'date-time'}, ('adoption', 'was_foster'): {'type': ['boolean', 'null']}, ('_sdc_received_at',): {'type': ['null', 'string'], 'format': 'date-time'}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_table_version',): {'type': ['null', 'integer']}, ('_sdc_batched_at',): {'type': ['null', 'string'], 'format': 'date-time'}}}}, {'type': 'TABLE_SCHEMA', 'path': ('adoption', 'immunizations'), 'level': 0, 'key_properties': ['_sdc_source_key_id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('type',): {'type': ['string']}, ('date_administered',): {'type': ['string'], 'format': 'date-time'}, ('adoption', 'immunizations', 'vaccination_type', 'shot'): {'type': ['string']}, ('_sdc_source_key_id',): {'type': ['integer']}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_level_0_id',): {'type': ['integer']}}}}]
___table_records:  {('adoption', 'immunizations'): [{('type',): ('string', 'Rabies'), ('date_administered',): ('string', '2537-09-12T13:34:00'), ('vaccination_type', 'shot'): ('string', 'Yes'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 0)}, {('type',): ('string', 'Panleukopenia'), ('date_administered',): ('string', '2889-03-01T17:18:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 1)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2599-08-08T07:47:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 2)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2902-04-14T01:34:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 3)}], (): [{('id',): ('integer', 1), ('name',): ('string', 'Morgan'), ('pattern',): ('string', 'Tortoiseshell'), ('age',): ('integer', 14), ('adoption', 'adopted_on'): ('string', '2633-01-02T00:11:00'), ('adoption', 'was_foster'): ('boolean', False), ('_sdc_batched_at',): ('string', '2019-04-05 09:00:15.4599+00:00'), ('_sdc_sequence',): ('integer', 1554384634)}]}
```

### After:
```
___table_schemas:  [{'type': 'TABLE_SCHEMA', 'path': (), 'level': None, 'key_properties': ['id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('id',): {'type': ['integer']}, ('name',): {'type': ['string']}, ('paw_size',): {'type': ['integer'], 'default': 314159}, ('paw_colour',): {'type': ['string'], 'default': ''}, ('flea_check_complete',): {'type': ['boolean'], 'default': False}, ('pattern',): {'type': ['null', 'string']}, ('age',): {'type': ['null', 'integer']}, ('adoption', 'adopted_on'): {'type': ['null', 'string'], 'format': 'date-time'}, ('adoption', 'was_foster'): {'type': ['boolean', 'null']}, ('_sdc_received_at',): {'type': ['null', 'string'], 'format': 'date-time'}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_table_version',): {'type': ['null', 'integer']}, ('_sdc_batched_at',): {'type': ['null', 'string'], 'format': 'date-time'}}}}, {'type': 'TABLE_SCHEMA', 'path': ('adoption', 'immunizations'), 'level': 0, 'key_properties': ['_sdc_source_key_id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('type',): {'type': ['string']}, ('date_administered',): {'type': ['string'], 'format': 'date-time'}, ('vaccination_type', 'shot'): {'type': ['null', 'string']}, ('_sdc_source_key_id',): {'type': ['integer']}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_level_0_id',): {'type': ['integer']}}}}]
___table_records:  {('adoption', 'immunizations'): [{('type',): ('string', 'Rabies'), ('date_administered',): ('string', '2537-09-12T13:34:00'), ('vaccination_type', 'shot'): ('string', 'Yes'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 0)}, {('type',): ('string', 'Panleukopenia'), ('date_administered',): ('string', '2889-03-01T17:18:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 1)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2599-08-08T07:47:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 2)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2902-04-14T01:34:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 3)}], (): [{('id',): ('integer', 1), ('name',): ('string', 'Morgan'), ('pattern',): ('string', 'Tortoiseshell'), ('age',): ('integer', 14), ('adoption', 'adopted_on'): ('string', '2633-01-02T00:11:00'), ('adoption', 'was_foster'): ('boolean', False), ('_sdc_batched_at',): ('string', '2019-04-05 12:05:11.2344+00:00'), ('_sdc_sequence',): ('integer', 1554384634)}]}
```
In the database for this example it now looks like this:
```
db=# \d
                     List of relations
 Schema |             Name              | Type  |  Owner   
--------+-------------------------------+-------+----------
 public | cats                          | table | postgres
 public | cats__adoption__immunizations | table | postgres
(2 rows)

db=# 
db=# 
db=# \d cats__adoption__immunizations 
                    Table "public.cats__adoption__immunizations"
         Column         |           Type           | Collation | Nullable | Default 
------------------------+--------------------------+-----------+----------+---------
 type                   | text                     |           | not null | 
 date_administered      | timestamp with time zone |           | not null | 
 vaccination_type__shot | text                     |           |          | 
 _sdc_source_key_id     | bigint                   |           | not null | 
 _sdc_sequence          | bigint                   |           |          | 
 _sdc_level_0_id        | bigint                   |           | not null | 

db=# select * from cats__adoption__immunizations
db-# ;
      type       |   date_administered    | vaccination_type__shot | _sdc_source_key_id | _sdc_sequence | _sdc_level_0_id 
-----------------+------------------------+------------------------+--------------------+---------------+-----------------
 Rabies          | 2537-09-12 15:34:00+02 | Yes                    |                  1 |    1554384634 |               0
 Panleukopenia   | 2889-03-01 18:18:00+01 | No                     |                  1 |    1554384634 |               1
 Feline Leukemia | 2599-08-08 09:47:00+02 | No                     |                  1 |    1554384634 |               2
 Feline Leukemia | 2902-04-14 03:34:00+02 | No                     |                  1 |    1554384634 |               3
(4 rows)
```
As you can see we now have data in the field `vaccination_type__shot` which didn't work before.