### PR TITLE
[bugfix] Fix for issue #109 - Nested records fix

### DIFF
--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -28,6 +28,7 @@ def to_table_batches(schema, key_properties, records):
 
     table_records = _get_streamed_table_records(key_properties,
                                                 records)
+
     writeable_batches = []
     for table_json_schema in table_schemas:
         writeable_batches.append({'streamed_schema': table_json_schema,
@@ -158,7 +159,7 @@ def _denest_schema(table_path, table_json_schema, key_prop_schemas, subtables, l
     for prop, item_json_schema in table_json_schema['properties'].items():
 
         if json_schema.is_object(item_json_schema):
-            _denest_schema_helper((prop,),
+            _denest_schema_helper(table_path + (prop,),
                                   item_json_schema,
                                   json_schema.is_nullable(item_json_schema),
                                   new_properties,
@@ -270,7 +271,7 @@ def _denest_record(table_path, record, records_map, key_properties, pk_fks, leve
             {...}
             """
             _denest_subrecord(table_path + (prop,),
-                              (prop,),
+                              table_path + (prop,),
                               denested_record,
                               value,
                               records_map,

--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -158,7 +158,7 @@ def _denest_schema(table_path, table_json_schema, key_prop_schemas, subtables, l
     for prop, item_json_schema in table_json_schema['properties'].items():
 
         if json_schema.is_object(item_json_schema):
-            _denest_schema_helper(table_path + (prop,),
+            _denest_schema_helper((prop,),
                                   item_json_schema,
                                   json_schema.is_nullable(item_json_schema),
                                   new_properties,


### PR DESCRIPTION
# Fix for issue #109 

Fixed by altering the record denesting.

The table_schemas and the table_records did not match for more complex and nested schemas. This is now fixed and they match. All nested data that I had trouble with before now enters the database as expected. One question remains: Is this the way we want to organize/structure the tables and naming of them? We could change the schemas denesting instead to match the record we had before, that will also work and that will give us a slightly different structure/naming of tables and objects.<br/>
Below you find an example of how the tables for schema and record mismatched before and how they now match for a simple example using data from the `CATS_SCHEMA` in target-postgres. Look for the `vaccination_type` especially.

### Before:
```
___table_schemas:  [{'type': 'TABLE_SCHEMA', 'path': (), 'level': None, 'key_properties': ['id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('id',): {'type': ['integer']}, ('name',): {'type': ['string']}, ('paw_size',): {'type': ['integer'], 'default': 314159}, ('paw_colour',): {'type': ['string'], 'default': ''}, ('flea_check_complete',): {'type': ['boolean'], 'default': False}, ('pattern',): {'type': ['null', 'string']}, ('age',): {'type': ['null', 'integer']}, ('adoption', 'adopted_on'): {'type': ['null', 'string'], 'format': 'date-time'}, ('adoption', 'was_foster'): {'type': ['boolean', 'null']}, ('_sdc_received_at',): {'type': ['null', 'string'], 'format': 'date-time'}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_table_version',): {'type': ['null', 'integer']}, ('_sdc_batched_at',): {'type': ['null', 'string'], 'format': 'date-time'}}}}, {'type': 'TABLE_SCHEMA', 'path': ('adoption', 'immunizations'), 'level': 0, 'key_properties': ['_sdc_source_key_id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('type',): {'type': ['string']}, ('date_administered',): {'type': ['string'], 'format': 'date-time'}, ('adoption', 'immunizations', 'vaccination_type', 'shot'): {'type': ['string']}, ('_sdc_source_key_id',): {'type': ['integer']}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_level_0_id',): {'type': ['integer']}}}}]
___table_records:  {('adoption', 'immunizations'): [{('type',): ('string', 'Rabies'), ('date_administered',): ('string', '2537-09-12T13:34:00'), ('vaccination_type', 'shot'): ('string', 'Yes'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 0)}, {('type',): ('string', 'Panleukopenia'), ('date_administered',): ('string', '2889-03-01T17:18:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 1)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2599-08-08T07:47:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 2)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2902-04-14T01:34:00'), ('vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 3)}], (): [{('id',): ('integer', 1), ('name',): ('string', 'Morgan'), ('pattern',): ('string', 'Tortoiseshell'), ('age',): ('integer', 14), ('adoption', 'adopted_on'): ('string', '2633-01-02T00:11:00'), ('adoption', 'was_foster'): ('boolean', False), ('_sdc_batched_at',): ('string', '2019-04-05 09:00:15.4599+00:00'), ('_sdc_sequence',): ('integer', 1554384634)}]}
```

### After:
```
___table_schemas:  [{'type': 'TABLE_SCHEMA', 'path': (), 'level': None, 'key_properties': ['id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('id',): {'type': ['integer']}, ('name',): {'type': ['string']}, ('paw_size',): {'type': ['integer'], 'default': 314159}, ('paw_colour',): {'type': ['string'], 'default': ''}, ('flea_check_complete',): {'type': ['boolean'], 'default': False}, ('pattern',): {'type': ['null', 'string']}, ('age',): {'type': ['null', 'integer']}, ('adoption', 'adopted_on'): {'type': ['null', 'string'], 'format': 'date-time'}, ('adoption', 'was_foster'): {'type': ['boolean', 'null']}, ('_sdc_received_at',): {'type': ['null', 'string'], 'format': 'date-time'}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_table_version',): {'type': ['null', 'integer']}, ('_sdc_batched_at',): {'type': ['null', 'string'], 'format': 'date-time'}}}}, {'type': 'TABLE_SCHEMA', 'path': ('adoption', 'immunizations'), 'level': 0, 'key_properties': ['_sdc_source_key_id'], 'mappings': [], 'schema': {'type': 'object', 'additionalProperties': False, 'properties': {('type',): {'type': ['string']}, ('date_administered',): {'type': ['string'], 'format': 'date-time'}, ('adoption', 'immunizations', 'vaccination_type', 'shot'): {'type': ['null', 'string']}, ('_sdc_source_key_id',): {'type': ['integer']}, ('_sdc_sequence',): {'type': ['null', 'integer']}, ('_sdc_level_0_id',): {'type': ['integer']}}}}]
___table_records:  {('adoption', 'immunizations'): [{('type',): ('string', 'Rabies'), ('date_administered',): ('string', '2537-09-12T13:34:00'), ('adoption', 'immunizations', 'vaccination_type', 'shot'): ('string', 'Yes'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 0)}, {('type',): ('string', 'Panleukopenia'), ('date_administered',): ('string', '2889-03-01T17:18:00'), ('adoption', 'immunizations', 'vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 1)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2599-08-08T07:47:00'), ('adoption', 'immunizations', 'vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 2)}, {('type',): ('string', 'Feline Leukemia'), ('date_administered',): ('string', '2902-04-14T01:34:00'), ('adoption', 'immunizations', 'vaccination_type', 'shot'): ('string', 'No'), ('_sdc_source_key_id',): ('integer', 1), ('_sdc_sequence',): ('integer', 1554384634), ('_sdc_level_0_id',): ('integer', 3)}], (): [{('id',): ('integer', 1), ('name',): ('string', 'Morgan'), ('pattern',): ('string', 'Tortoiseshell'), ('age',): ('integer', 14), ('adoption', 'adopted_on'): ('string', '2633-01-02T00:11:00'), ('adoption', 'was_foster'): ('boolean', False), ('_sdc_batched_at',): ('string', '2019-04-05 13:19:50.0198+00:00'), ('_sdc_sequence',): ('integer', 1554384634)}]}
```
In the database for this example it now looks like this:
```
db=# \d
                     List of relations
 Schema |             Name              | Type  |  Owner   
--------+-------------------------------+-------+----------
 public | cats                          | table | postgres
 public | cats__adoption__immunizations | table | postgres
(2 rows)

db=# \d cats
                               Table "public.cats"
        Column        |           Type           | Collation | Nullable | Default 
----------------------+--------------------------+-----------+----------+---------
 id                   | bigint                   |           | not null | 
 name                 | text                     |           | not null | 
 paw_size             | bigint                   |           | not null | 
 paw_colour           | text                     |           | not null | 
 flea_check_complete  | boolean                  |           | not null | 
 pattern              | text                     |           |          | 
 age                  | bigint                   |           |          | 
 adoption__adopted_on | timestamp with time zone |           |          | 
 adoption__was_foster | boolean                  |           |          | 
 _sdc_received_at     | timestamp with time zone |           |          | 
 _sdc_sequence        | bigint                   |           |          | 
 _sdc_table_version   | bigint                   |           |          | 
 _sdc_batched_at      | timestamp with time zone |           |          | 

db=# \d cats__adoption__immunizations 
                                Table "public.cats__adoption__immunizations"
                     Column                      |           Type           | Collation | Nullable | Default 
-------------------------------------------------+--------------------------+-----------+----------+---------
 type                                            | text                     |           | not null | 
 date_administered                               | timestamp with time zone |           | not null | 
 adoption__immunizations__vaccination_type__shot | text                     |           |          | 
 _sdc_source_key_id                              | bigint                   |           | not null | 
 _sdc_sequence                                   | bigint                   |           |          | 
 _sdc_level_0_id                                 | bigint                   |           | not null | 

db=# 
db=# select * from cats__adoption__immunizations;
      type       |   date_administered    | adoption__immunizations__vaccination_type__shot | _sdc_source_key_id | _sdc_sequence | _sdc_level_0_id 
-----------------+------------------------+-------------------------------------------------+--------------------+---------------+-----------------
 Rabies          | 2537-09-12 15:34:00+02 | Yes                                             |                  1 |    1554384634 |               0
 Panleukopenia   | 2889-03-01 18:18:00+01 | No                                              |                  1 |    1554384634 |               1
 Feline Leukemia | 2599-08-08 09:47:00+02 | No                                              |                  1 |    1554384634 |               2
 Feline Leukemia | 2902-04-14 03:34:00+02 | No                                              |                  1 |    1554384634 |               3
(4 rows)
```
As you can see we now have data in the field `adoption__immunizations__vaccination_type__shot` which didn't work before.