### PR TITLE
Send STATE records to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install singer-target-postgres
    ```bash
    ~/.virtualenvs/tap-something/bin/tap-something \
      | ~/.virtualenvs/target-postgres/bin/target-postgres \
-       --config ~/singer.io/target_postgres_config.json
+       --config ~/singer.io/target_postgres_config.json >> state.json
    ```
 
 ### Config.json
@@ -93,7 +93,6 @@ _The above is copied from the [current list of versions](https://www.postgresql.
 
 ## Known Limitations
 
-- Ignores `STATE` Singer messages.
 - Requires a [JSON Schema](https://json-schema.org/) for every stream.
 - Only string, string with date-time format, integer, number, boolean,
   object, and array types with or without null are supported. Arrays can

--- a/tests/test_target_tools.py
+++ b/tests/test_target_tools.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import json
 
 from unittest.mock import patch
 import pytest
@@ -70,3 +71,19 @@ def test_loading__invalid__records__threshold():
         target_tools.stream_to_target(InvalidCatStream(20), target, config=config)
 
     assert len(target.calls['write_batch']) == 0
+
+
+def test_state__capture(capsys):
+    stream = [
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }}),
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})]
+
+    target_tools.stream_to_target(stream, Target())
+
+    out, _ = capsys.readouterr()
+
+    filtered_output = list(filter(None, out.split('\n')))
+
+    assert len(filtered_output) == 2
+    assert json.loads(filtered_output[0])['test'] == 'state-1'
+    assert json.loads(filtered_output[1])['test'] == 'state-2'


### PR DESCRIPTION
Fixes #117 


This will pass all `STATE` records to stdout.

The command could now be:

`tap | target >> state.json`

And the resulting state file would look something like this:

```
{ "users": 1 }
{ "users": 2 }
```

With this approach, if the end user only cares about the latest
`STATE` record, they can manually handle updating their state file:

`tail -1 state.json > state.json.tmp && mv state.json.tmp state.json`