### PR TITLE
Bump psycopg2 from 2.7.7 -> 2.8.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ setup(
     py_modules=['target_postgres'],
     install_requires=[
         'arrow==0.13.0',
-        'psycopg2==2.7.7',
-        'psycopg2-binary==2.7.7',
+        'psycopg2==2.8.2',
+        'psycopg2-binary==2.8.2',
         'singer-python==5.6.0'
     ],
     setup_requires=[

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -159,7 +159,7 @@ def test_loading__invalid__default_null_value__non_nullable_column(db_cleanup):
             record['name'] = postgres.RESERVED_NULL_DEFAULT
             return record
 
-    with pytest.raises(postgres.PostgresError, match=r'.*IntegrityError.*'):
+    with pytest.raises(postgres.PostgresError, match=r'.*NotNullViolation.*'):
         main(CONFIG, input_stream=NullDefaultCatStream(20))
 
 


### PR DESCRIPTION
Fixes #119

psycopg2 2.8 release introduced mappings between Postgresql errors
and python exceptions.

I assume this came with additional, more granular exceptions that are
now subclassed.

If the original code had been throwing the `IntegrityError` exception, the
code would have still worked, since the `NotNullValidation` is a subclass.
However, since the exception is wrapped in `postgres.PostgresError` and
it's using a matcher, the matching string had to be updated to match the
new exception being thrown.

REFERENCES:
* http://initd.org/psycopg/articles/2019/04/04/psycopg-28-released/
* http://initd.org/psycopg/docs/errors.html