### PR TITLE
Send STATE records to stdout with eager flushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ here.
 | `disable_collection`        | `["string", "null"]`  | `false`                          | Include `true` in your config to disable [Singer Usage Logging](#usage-logging).                                                                                                                                                 |
 | `logging_level`             | `["string", "null"]`  | `"INFO"`                         | The level for logging. Set to `DEBUG` to get things like queries executed, timing of those queries, etc. See [Python's Logger Levels](https://docs.python.org/3/library/logging.html#levels) for information about valid values. |
 | `persist_empty_tables`      | `["boolean", "null"]` | `False`                          | Whether the Target should create tables which have no records present in Remote.                                                                                                                                                 |
+| `state_support`             | `["boolean", "null"]` | `True`        | Whether the Target should emit `STATE` messages to stdout for further consumption. In this mode, `STATE` messages trigger flushing all unpersisted records from the tap.                                                   |
 
 ### Supported Versions
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install singer-target-postgres
    ```bash
    ~/.virtualenvs/tap-something/bin/tap-something \
      | ~/.virtualenvs/target-postgres/bin/target-postgres \
-       --config ~/singer.io/target_postgres_config.json
+       --config ~/singer.io/target_postgres_config.json >> state.json
    ```
 
 ### Config.json
@@ -98,7 +98,6 @@ _The above is copied from the [current list of versions](https://www.postgresql.
 
 ## Known Limitations
 
-- Ignores `STATE` Singer messages.
 - Requires a [JSON Schema](https://json-schema.org/) for every stream.
 - Only string, string with date-time format, integer, number, boolean,
   object, and array types with or without null are supported. Arrays can

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ _The above is copied from the [current list of versions](https://www.postgresql.
 ## Known Limitations
 
 - Requires a [JSON Schema](https://json-schema.org/) for every stream.
+- Eagerly flushes records to the database upon recieving a STATE message, which can be frequently if a tap is emitting STATE messages often.
 - Only string, string with date-time format, integer, number, boolean,
   object, and array types with or without null are supported. Arrays can
   have any of the other types listed, including objects as types within

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -51,6 +51,7 @@ def stream_to_target(stream, target, config={}):
         line_count = 0
         for line in stream:
             _line_handler(streams,
+                          state,
                           target,
                           invalid_records_detect,
                           invalid_records_threshold,
@@ -166,6 +167,7 @@ def _line_handler(streams, target, invalid_records_detect, invalid_records_thres
         target.activate_version(stream_buffer, line_data['version'])
     elif line_data['type'] == 'STATE':
         line = json.dumps(line_data['value'])
+        _flush_streams(streams, target, force=True)
         state_writer.write("{}\n".format(line))
         state_writer.flush()
     else:

--- a/tests/test_target_tools.py
+++ b/tests/test_target_tools.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import json
 
 from unittest.mock import patch
 import pytest
@@ -70,3 +71,19 @@ def test_loading__invalid__records__threshold():
         target_tools.stream_to_target(InvalidCatStream(20), target, config=config)
 
     assert len(target.calls['write_batch']) == 0
+
+
+def test_state__capture(capsys):
+    stream = [
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }}),
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})]
+
+    target_tools.stream_to_target(stream, Target())
+
+    out, _ = capsys.readouterr()
+
+    filtered_output = list(filter(None, out.split('\n')))
+
+    assert len(filtered_output) == 2
+    assert json.loads(filtered_output[0])['test'] == 'state-1'
+    assert json.loads(filtered_output[1])['test'] == 'state-2'


### PR DESCRIPTION
This is on top of #120 and would supersede it if accepted. This adds less buggy support for `STATE` messages as well as a config option to turn off the new behaviour. 

This adds support for writing `STATE` messages to stdout for an orchestrator of some sort to persist and feed back into the next invocation of the tap. It's a little trickier than one would hope because the `STATE` message is a checkpoint of sorts for the whole system. If data from before a `STATE` message is lost somehow, and the tap is rerun starting from that state, that data would be permanently lost, so it's important that all records from before a given `STATE` have been saved to the database before that `STATE` is emitted.

The Singer spec however does not specify what exactly is in STATE messages, so, they can relate to any or all of the active streams. That means that target-postgres doesn't and can't know which records that it may have buffered in memory are "covered" by an incoming STATE record. If target-postgres eagerly emitted the STATE record to stdout, but didn't flush all the records, the system becomes open to inconsistency. If the STATE message were persisted by the outside orchestrator, but then the process crashed later, the buffers in target-postgres process would be lost and data dropped. The implementation prior to this commit suffers from this bug, see #120 for more discussion.

We prevent this bug by eagerly flushing all the buffered records whenever a STATE message is encountered. When the orchestrator sees a STATE message, it becomes guaranteed safe to persist it as everything seen from the tap has been committed to the database.

The downside of this approach is that it may lead to superfluous flushes of the buffered streams, especially if a tap emits a lot of STATE messages. From my experience with several different taps, they all tend to be written in such a way that they emit STATE messages as a single last step, so I don't think this is too big an issue.

An alternative to this approach would be tracking which records were received before a given STATE message, and then only writing the STATE message out to the orchestrator once all those records had been flushed on their regularly scheduled programming. This means STATE messages are "delayed" until the records they came after have all been flushed on the schedule they would have been flushed on without STATE messages. target-snowflake implements this here: https://gitlab.com/meltano/target-snowflake/blob/master/target_snowflake/target_snowflake.py , but in my mind, this is significant additional complexity for a performance optimization that is in most circumstances unnecessary. It's arguable that writing STATE messages to stdout as soon as they arrive is actually valuable, so that in the presence of a sometimes-failing tap progress can actually be made by getting STATE persisted as soon as possible, and, while the taps are indeed idempotent, rerunning them isn't always free (in terms of API calls and whatnot). So, I think this simpler solution would be a great starting point, and after some real world usage we could re-evaluate and move to the more complex approach.
