### PR TITLE
Performant STATE message flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install singer-target-postgres
      | ~/.virtualenvs/target-postgres/bin/target-postgres \
        --config ~/singer.io/target_postgres_config.json >> state.json
    ```
-   
+
    If you are running windows, the following is equivalent:
    ```
    venvs\tap-exchangeratesapi\Scripts\tap-exchangeratesapi.exe | ^
@@ -82,7 +82,7 @@ here.
 | `disable_collection`        | `["string", "null"]`  | `false`                          | Include `true` in your config to disable [Singer Usage Logging](#usage-logging).                                                                                                                                                 |
 | `logging_level`             | `["string", "null"]`  | `"INFO"`                         | The level for logging. Set to `DEBUG` to get things like queries executed, timing of those queries, etc. See [Python's Logger Levels](https://docs.python.org/3/library/logging.html#levels) for information about valid values. |
 | `persist_empty_tables`      | `["boolean", "null"]` | `False`                          | Whether the Target should create tables which have no records present in Remote.                                                                                                                                                 |
-| `state_support`             | `["boolean", "null"]` | `True`        | Whether the Target should emit `STATE` messages to stdout for further consumption. In this mode, `STATE` messages trigger flushing all unpersisted records from the tap.                                                   |
+| `state_support`             | `["boolean", "null"]` | `True`                           | Whether the Target should emit `STATE` messages to stdout for further consumption. In this mode, which is on by default, STATE messages are buffered in memory until all the records that occurred before them are flushed according to the batch flushing schedule the target is configured with.    |
 
 ### Supported Versions
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install singer-target-postgres
    ```bash
    ~/.virtualenvs/tap-something/bin/tap-something \
      | ~/.virtualenvs/target-postgres/bin/target-postgres \
-       --config ~/singer.io/target_postgres_config.json
+       --config ~/singer.io/target_postgres_config.json >> state.json
    ```
    
    If you are running windows, the following is equivalent:
@@ -105,7 +105,6 @@ _The above is copied from the [current list of versions](https://www.postgresql.
 
 ## Known Limitations
 
-- Ignores `STATE` Singer messages.
 - Requires a [JSON Schema](https://json-schema.org/) for every stream.
 - Only string, string with date-time format, integer, number, boolean,
   object, and array types with or without null are supported. Arrays can

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ here.
 | `disable_collection`        | `["string", "null"]`  | `false`                          | Include `true` in your config to disable [Singer Usage Logging](#usage-logging).                                                                                                                                                 |
 | `logging_level`             | `["string", "null"]`  | `"INFO"`                         | The level for logging. Set to `DEBUG` to get things like queries executed, timing of those queries, etc. See [Python's Logger Levels](https://docs.python.org/3/library/logging.html#levels) for information about valid values. |
 | `persist_empty_tables`      | `["boolean", "null"]` | `False`                          | Whether the Target should create tables which have no records present in Remote.                                                                                                                                                 |
+| `state_support`             | `["boolean", "null"]` | `True`        | Whether the Target should emit `STATE` messages to stdout for further consumption. In this mode, `STATE` messages trigger flushing all unpersisted records from the tap.                                                   |
 
 ### Supported Versions
 

--- a/target_postgres/exceptions.py
+++ b/target_postgres/exceptions.py
@@ -1,0 +1,22 @@
+class JSONSchemaError(Exception):
+    """
+    Raise this when there is an error with regards to an instance of JSON Schema
+    """
+
+
+class TargetError(Exception):
+    """
+    Raise when there is an Exception streaming data to the target.
+    """
+
+
+class PostgresError(Exception):
+    """
+    Raise this when there is an error with regards to Postgres streaming
+    """
+
+
+class SingerStreamError(Exception):
+    """
+    Raise when there is an Exception with Singer Streams.
+    """

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -3,6 +3,7 @@ import re
 
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import SchemaError
+from target_postgres.exceptions import JSONSchemaError
 
 NULL = 'null'
 OBJECT = 'object'
@@ -20,12 +21,6 @@ _PYTHON_TYPE_TO_JSON_SCHEMA = {
     str: STRING,
     type(None): NULL
 }
-
-
-class JSONSchemaError(Exception):
-    """
-    Raise this when there is an error with regards to an instance of JSON Schema
-    """
 
 
 def python_type(x):

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -12,6 +12,7 @@ from psycopg2 import sql
 from psycopg2.extras import LoggingConnection, LoggingCursor
 
 from target_postgres import json_schema
+from target_postgres.exceptions import PostgresError
 from target_postgres.sql_base import SEPARATOR, SQLInterface
 from target_postgres.singer_stream import (
     SINGER_SEQUENCE,
@@ -72,11 +73,6 @@ class MillisLoggingConnection(LoggingConnection):
         kwargs.setdefault('cursor_factory', _MillisLoggingCursor)
         return LoggingConnection.cursor(self, *args, **kwargs)
 
-
-class PostgresError(Exception):
-    """
-    Raise this when there is an error with regards to Postgres streaming
-    """
 
 
 class TransformStream:

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -6,13 +6,8 @@ from jsonschema import Draft4Validator, FormatChecker
 from jsonschema.exceptions import ValidationError
 
 from target_postgres import json_schema
+from target_postgres.exceptions import SingerStreamError
 from target_postgres.pysize import get_size
-
-
-class SingerStreamError(Exception):
-    """
-    Raise when there is an Exception with Singer Streams.
-    """
 
 
 SINGER_RECEIVED_AT = '_sdc_received_at'

--- a/target_postgres/state_tracker.py
+++ b/target_postgres/state_tracker.py
@@ -1,0 +1,24 @@
+import json
+import sys
+
+class StateTracker:
+  def __init__(self, target, emit_states):
+    self.target = target
+    self.emit_states = emit_states
+
+    self.streams = {}
+    self.last_emitted_state = None
+    self.state_queue = []
+
+  def flush_streams(self, force=False):
+    for stream_buffer in self.streams.values():
+        if force or stream_buffer.buffer_full:
+          self.target.write_batch(stream_buffer)
+          stream_buffer.flush_buffer()
+
+
+  def emit_state(self, value):
+    if self.emit_states:
+      line = json.dumps(value)
+      sys.stdout.write("{}\n".format(line))
+      sys.stdout.flush()

--- a/target_postgres/state_tracker.py
+++ b/target_postgres/state_tracker.py
@@ -1,24 +1,73 @@
+from collections import deque
 import json
 import sys
 
+
+class TargetError(Exception):
+    """
+    Raise when there is an Exception streaming data to the target.
+    """
+
+
 class StateTracker:
-  def __init__(self, target, emit_states):
-    self.target = target
-    self.emit_states = emit_states
+    """
+    Object to track STATE messages coming in from the tap and which streams need to be flushed before they can be safely emitted.
+    Because Singer taps don't have a standard way of expressing which streams correspond to which STATEs, the target can only safely
+    emit a STATE message once all the records that came in prior to that STATE in the stream. Because target-postgres buffers
+    the records in BufferedSingerStreams, the STATE messages need to be delayed until all the records that came before them have been
+    saved to the database from their buffers.
+    """
 
-    self.streams = {}
-    self.last_emitted_state = None
-    self.state_queue = []
+    def __init__(self, target, emit_states):
+        self.target = target
+        self.emit_states = emit_states
 
-  def flush_streams(self, force=False):
-    for stream_buffer in self.streams.values():
-        if force or stream_buffer.buffer_full:
-          self.target.write_batch(stream_buffer)
-          stream_buffer.flush_buffer()
+        self.streams = {}
+        self.stream_add_watermarks = {}
+        self.stream_flush_watermarks = {}
 
+        self.state_queue = deque()  # contains dicts of {'state': <state blob>, 'watermark': number}
+        self.message_counter = 0
 
-  def emit_state(self, value):
-    if self.emit_states:
-      line = json.dumps(value)
-      sys.stdout.write("{}\n".format(line))
-      sys.stdout.flush()
+    def register_stream(self, stream, buffered_stream):
+        self.streams[stream] = buffered_stream
+        self.stream_add_watermarks[stream] = 0
+        self.stream_flush_watermarks[stream] = 0
+
+    def flush_streams(self, force=False):
+        for (stream, stream_buffer) in self.streams.items():
+            if force or stream_buffer.buffer_full:
+                self.target.write_batch(stream_buffer)
+                stream_buffer.flush_buffer()
+                self.stream_flush_watermarks[stream] = self.stream_add_watermarks[stream]
+
+        self._emit_safe_queued_states(force=force)
+
+    def handle_state_message(self, value):
+        if self.emit_states:
+            self.state_queue.append({'state': value, 'watermark': self.message_counter})
+            self._emit_safe_queued_states()
+
+    def handle_record_message(self, stream, line_data):
+        if stream not in self.streams:
+            raise TargetError('A record for stream {} was encountered before a corresponding schema'.format(stream))
+
+        self.message_counter += 1
+        self.stream_add_watermarks[stream] = self.message_counter
+        self.streams[stream].add_record_message(line_data)
+
+    def _emit_safe_queued_states(self, force=False):
+        # State messages that occured before the least recently flushed record are safe to emit.
+        # If they occurred after some records that haven't yet been flushed, they aren't safe to emit.
+        # Because records arrive at different rates from different streams, we take the earliest unflushed record as the threshold for what
+        # STATE messages are safe to emit.
+        all_flushed_watermark = min(self.stream_flush_watermarks.values(), default=0)
+        emittable_state = None
+
+        while len(self.state_queue) > 0 and (force or self.state_queue[0]['watermark'] <= all_flushed_watermark):
+            emittable_state = self.state_queue.popleft()['state']
+
+        if emittable_state:
+            line = json.dumps(emittable_state)
+            sys.stdout.write("{}\n".format(line))
+            sys.stdout.flush()

--- a/target_postgres/stream_tracker.py
+++ b/target_postgres/stream_tracker.py
@@ -1,13 +1,9 @@
 from collections import deque
 import json
-import sys
 import singer.statediff as statediff
+import sys
 
-
-class TargetError(Exception):
-    """
-    Raise when there is an Exception streaming data to the target.
-    """
+from target_postgres.exceptions import TargetError
 
 
 class StreamTracker:

--- a/target_postgres/stream_tracker.py
+++ b/target_postgres/stream_tracker.py
@@ -10,9 +10,10 @@ class TargetError(Exception):
     """
 
 
-class StateTracker:
+class StreamTracker:
     """
-    Object to track STATE messages coming in from the tap and which streams need to be flushed before they can be safely emitted.
+    Object to track the BufferedStream objects for each incoming stream to the target, and the STATE messages coming in. This object understands which streams need to be flushed before STATE messages can be safely emitted and does so.
+
     Because Singer taps don't have a standard way of expressing which streams correspond to which STATEs, the target can only safely
     emit a STATE message once all the records that came in prior to that STATE in the stream. Because target-postgres buffers
     the records in BufferedSingerStreams, the STATE messages need to be delayed until all the records that came before them have been

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -10,7 +10,7 @@ from singer import utils, metadata, metrics
 
 from target_postgres import json_schema
 from target_postgres.singer_stream import BufferedSingerStream
-from target_postgres.state_tracker import StateTracker, TargetError
+from target_postgres.stream_tracker import StreamTracker, TargetError
 
 LOGGER = singer.get_logger()
 
@@ -38,7 +38,7 @@ def stream_to_target(stream, target, config={}):
     """
 
     state_support = config.get('state_support', True)
-    state_tracker = StateTracker(target, state_support)
+    state_tracker = StreamTracker(target, state_support)
 
     try:
         if not config.get('disable_collection', False):

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -47,6 +47,7 @@ def stream_to_target(stream, target, config={}):
         max_batch_rows = config.get('max_batch_rows')
         max_batch_size = config.get('max_batch_size')
         batch_detection_threshold = config.get('batch_detection_threshold', 5000)
+        state_support = config.get('state_support', True)
 
         line_count = 0
         for line in stream:
@@ -57,7 +58,9 @@ def stream_to_target(stream, target, config={}):
                           max_batch_rows,
                           max_batch_size,
                           line,
-                          state_writer)
+                          state_support,
+                          state_writer
+            )
             if line_count > 0 and line_count % batch_detection_threshold == 0:
                 _flush_streams(streams, target)
             line_count += 1
@@ -100,7 +103,7 @@ def _report_invalid_records(streams):
 
 
 def _line_handler(streams, target, invalid_records_detect, invalid_records_threshold, max_batch_rows, max_batch_size,
-                  line, state_writer):
+                  line, state_support, state_writer):
     try:
         line_data = json.loads(line)
     except json.decoder.JSONDecodeError:
@@ -165,9 +168,10 @@ def _line_handler(streams, target, invalid_records_detect, invalid_records_thres
         target.write_batch(stream_buffer)
         target.activate_version(stream_buffer, line_data['version'])
     elif line_data['type'] == 'STATE':
-        line = json.dumps(line_data['value'])
-        state_writer.write("{}\n".format(line))
-        state_writer.flush()
+        if state_support:
+            line = json.dumps(line_data['value'])
+            state_writer.write("{}\n".format(line))
+            state_writer.flush()
     else:
         raise TargetError('Unknown message type {} in message {}'.format(
             line_data['type'],

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -9,8 +9,10 @@ import singer
 from singer import utils, metadata, metrics
 
 from target_postgres import json_schema
+from target_postgres.exceptions import TargetError
 from target_postgres.singer_stream import BufferedSingerStream
-from target_postgres.stream_tracker import StreamTracker, TargetError
+from target_postgres.stream_tracker import StreamTracker
+
 
 LOGGER = singer.get_logger()
 

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -148,7 +148,7 @@ def _line_handler(state_tracker, target, invalid_records_detect, invalid_records
         target.write_batch(stream_buffer)
         target.activate_version(stream_buffer, line_data['version'])
     elif line_data['type'] == 'STATE':
-        state_tracker.handle_state_message(line_data['value'])
+        state_tracker.handle_state_message(line_data)
     else:
         raise TargetError('Unknown message type {} in message {}'.format(
             line_data['type'],

--- a/tests/test_target_tools.py
+++ b/tests/test_target_tools.py
@@ -87,8 +87,8 @@ def test_state__capture(capsys):
     output = filtered_output(capsys)
 
     assert len(output) == 2
-    assert json.loads(output[0])['test'] == 'state-1'
-    assert json.loads(output[1])['test'] == 'state-2'
+    assert json.loads(output[0])['value']['test'] == 'state-1'
+    assert json.loads(output[1])['value']['test'] == 'state-2'
 
 
 def test_state__capture_can_be_disabled(capsys):
@@ -134,7 +134,7 @@ def test_state__emits_only_messages_when_all_records_before_have_been_flushed(ca
         assert len(target.calls['write_batch']) == 1
         output = filtered_output(capsys)
         assert len(output) == 1
-        assert json.loads(output[0])['test'] == 'state-3'
+        assert json.loads(output[0])['value']['test'] == 'state-3'
 
         for row in rows[slice(26, 31)]:
             yield row
@@ -144,7 +144,7 @@ def test_state__emits_only_messages_when_all_records_before_have_been_flushed(ca
     # The final state message should have been outputted after the last records were loaded
     output = filtered_output(capsys)
     assert len(output) == 1
-    assert json.loads(output[0])['test'] == 'state-4'
+    assert json.loads(output[0])['value']['test'] == 'state-4'
 
 
 def test_state__emits_most_recent_state_when_final_flush_occurs(capsys):
@@ -160,7 +160,7 @@ def test_state__emits_most_recent_state_when_final_flush_occurs(capsys):
     # one full flushable batch
     output = filtered_output(capsys)
     assert len(output) == 1
-    assert json.loads(output[0])['test'] == 'state-1'
+    assert json.loads(output[0])['value']['test'] == 'state-1'
 
 
 class DogStream(CatStream):
@@ -211,14 +211,14 @@ def test_state__doesnt_emit_when_only_one_of_several_streams_is_flushing(capsys)
         assert len(target.calls['write_batch']) == 4
         output = filtered_output(capsys)
         assert len(output) == 1
-        assert json.loads(output[0])['test'] == 'state-2'
+        assert json.loads(output[0])['value']['test'] == 'state-2'
 
     target_tools.stream_to_target(test_stream(), target, config=config)
 
     # The final state message should have been outputted after the last dog records were loaded despite not reaching one full flushable batch
     output = filtered_output(capsys)
     assert len(output) == 1
-    assert json.loads(output[0])['test'] == 'state-4'
+    assert json.loads(output[0])['value']['test'] == 'state-4'
 
 
 def test_state__doesnt_emit_when_it_isnt_different_than_the_previous_emission(capsys):

--- a/tests/test_target_tools.py
+++ b/tests/test_target_tools.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import json
 
 from unittest.mock import patch
 import pytest
@@ -70,3 +71,19 @@ def test_loading__invalid__records__threshold():
         target_tools.stream_to_target(InvalidCatStream(20), target, config=config)
 
     assert len(target.calls['write_batch']) == 0
+
+
+def test_state__capture(capsys):
+    stream = [
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }}),
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})]
+
+    target_tools.stream_to_target(stream, Target())
+
+    out, _ = capsys.readouterr()
+
+    filtered_output = list(filter(None, out.split('\n')))
+
+    assert len(filtered_output) == 2
+    assert json.loads(filtered_output[0])['test'] == 'state-1'
+    assert json.loads(filtered_output[1])['test'] == 'state-2'

--- a/tests/test_target_tools.py
+++ b/tests/test_target_tools.py
@@ -87,3 +87,17 @@ def test_state__capture(capsys):
     assert len(filtered_output) == 2
     assert json.loads(filtered_output[0])['test'] == 'state-1'
     assert json.loads(filtered_output[1])['test'] == 'state-2'
+
+
+def test_state__capture_can_be_disabled(capsys):
+    stream = [
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }}),
+        json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})]
+
+    target_tools.stream_to_target(stream, Target(), {'state_support': False})
+
+    out, _ = capsys.readouterr()
+
+    filtered_output = list(filter(None, out.split('\n')))
+
+    assert len(filtered_output) == 0


### PR DESCRIPTION
This is on top of #120 and a follow up to #128. 

In order for orchestrating systems to properly keep track of the STATE of Singer streams, target-postgres needs to emit the STATE messages it receives from the tap to stdout for the orchestrator to persist. This keeps target-postgres Singer-spec compliant and lets users pass that STATE back into the tap to incrementally load from any big sources.

The Singer spec however does not specify what exactly is in STATE messages, so, they can relate to any or all of the active streams. That means that target-postgres doesn't and can't know which records that it may have buffered in memory are "covered" by an incoming STATE record. If target-postgres eagerly emitted the STATE record to stdout, but didn't flush all the records, the system becomes open to inconsistency. If the STATE message were persisted by the outside orchestrator, but then the process crashed later, the buffers in target-postgres process would be lost and data dropped. The implementation from #120 suffers from this bug, see #120 for more discussion.

This commit prevents this bug by "late" flushing buffered STATE messages when all the records that arrived prior to that STATE message have been flushed. STATE messages are "delayed" until the records that came before have all been put on a buffered stream and then flushed. target-snowflake implements this here: https://gitlab.com/meltano/target-snowflake/blob/master/target_snowflake/target_snowflake.py.

This is accomplished by keeping a low watermark of the least recently arriving record for each stream, and upon flushing a buffer, checking to see if there are any unflushed STATE messages that have become safe to flush because they are below that watermark. The way to think about this is as a "safety cursor" that lags behind the incoming stream, pointing to the point in the stream where all records before that point have been saved to the database. Some records ahead of that point will likely have been saved, as different streams records may be interleaved or arriving at different rates, but because of the whole "states are on one timeline different than each stream" thing, the STATE message has to wait for all prior records to be flushed.

This is implemented using a new StateTracker class, which wraps a bit of business logic around the old streams dict that is used to hold the BufferedSingerStream objects. I'm happy to get feedback on the style or further refactorings that this might prompt so please review away. I tried to make this change in a not super invasive way such that we could potentially chunk up further changes into future PRs. 