### PR TITLE
Feature/stream name  root table  canonicalization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,7 @@ jobs:
           name: Data -> Target
           command: |
             source venv--target-postgres/bin/activate
+            pip install .
             cd /code/.circleci/integration
 
             cat /code/artifacts/data/tap | target-postgres --config target-config.json
@@ -255,6 +256,7 @@ jobs:
           name: Repeatability of Data -> Target
           command: |
             source venv--target-postgres/bin/activate
+            pip install .
             cd /code/.circleci/integration
 
             cat /code/artifacts/data/tap | target-postgres --config target-config.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
           command: |
             python -m venv venv--target-postgres
             source venv--target-postgres/bin/activate
-            python setup.py install
+            pip install -e .[tests]
             deactivate
 
       - run:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 python -m venv venv--target-postgres
 source /code/venv--target-postgres/bin/activate
 
-pip install -e .
+pip install -e .[tests]
 
 echo -e "\n\nINFO: Dev environment ready."
 

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,12 @@ setup(
     setup_requires=[
         "pytest-runner"
     ],
-    tests_require=[
-        "chance==0.110",
-        "Faker==1.0.7",
-        "pytest==4.5.0"
-    ],
+    extras_require={
+        'tests': [
+            "chance==0.110",
+            "Faker==1.0.7",
+            "pytest==4.5.0"
+        ]},
     entry_points='''
       [console_scripts]
       target-postgres=target_postgres:cli

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -89,7 +89,8 @@ class PostgresTarget(SQLInterface):
     # TODO: Figure out way to `SELECT` value from commands
     IDENTIFIER_FIELD_LENGTH = 63
 
-    def __init__(self, connection, *args, postgres_schema='public', logging_level=None, persist_empty_tables=False, **kwargs):
+    def __init__(self, connection, *args, postgres_schema='public', logging_level=None, persist_empty_tables=False,
+                 **kwargs):
         self.LOGGER.info(
             'PostgresTarget created with established connection: `{}`, PostgreSQL schema: `{}`'.format(connection.dsn,
                                                                                                        postgres_schema))
@@ -114,19 +115,35 @@ class PostgresTarget(SQLInterface):
         return {'database': self.conn.get_dsn_parameters().get('dbname', None),
                 'schema': self.postgres_schema}
 
+    def setup_table_mapping_cache(self, cur):
+        self.table_mapping_cache = {}
+
+        cur.execute(
+            sql.SQL('''
+                SELECT c.relname, CAST(obj_description(c.oid) AS json)->'path'
+                FROM pg_namespace AS n
+                  INNER JOIN pg_class AS c ON n.oid = c.relnamespace
+                WHERE n.nspname = {};
+                ''').format(sql.Literal(self.postgres_schema)))
+
+        for column in cur.fetchall():
+            self.LOGGER.info("Mapping: {}".format(column))
+            if column[1]:
+                table_path = tuple(column[1])
+                self.table_mapping_cache[table_path] = column[0]
+
     def write_batch(self, stream_buffer):
         if not self.persist_empty_tables and stream_buffer.count == 0:
             return None
 
         with self.conn.cursor() as cur:
             try:
-                self._validate_identifier(stream_buffer.stream)
-
                 cur.execute('BEGIN;')
 
-                current_table_schema = self.get_table_schema(cur,
-                                                             (stream_buffer.stream,),
-                                                             stream_buffer.stream)
+                self.setup_table_mapping_cache(cur)
+
+                root_table_name = self.add_table_mapping(cur, (stream_buffer.stream,), {})
+                current_table_schema = self.get_table_schema(cur, None, root_table_name)
 
                 current_table_version = None
 
@@ -158,8 +175,14 @@ class PostgresTarget(SQLInterface):
                                     self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property])
                                 ))
 
-                root_table_name = stream_buffer.stream
                 target_table_version = current_table_version or stream_buffer.max_version
+
+                self.LOGGER.info('Stream {} ({}) with max_version {} targetting {}'.format(
+                    stream_buffer.stream,
+                    root_table_name,
+                    stream_buffer.max_version,
+                    target_table_version
+                ))
 
                 if current_table_version is not None and \
                         stream_buffer.max_version is not None:
@@ -170,8 +193,10 @@ class PostgresTarget(SQLInterface):
                         return None
 
                     elif stream_buffer.max_version > current_table_version:
-                        root_table_name = stream_buffer.stream + SEPARATOR + str(stream_buffer.max_version)
+                        root_table_name += SEPARATOR + str(stream_buffer.max_version)
                         target_table_version = stream_buffer.max_version
+
+                self.LOGGER.info('Root table name {}'.format(root_table_name))
 
                 self._validate_identifier(root_table_name)
                 written_batches_details = self.write_batch_helper(cur,
@@ -195,18 +220,21 @@ class PostgresTarget(SQLInterface):
             try:
                 cur.execute('BEGIN;')
 
-                table_metadata = self._get_table_metadata(cur,
-                                                          stream_buffer.stream)
+                self.setup_table_mapping_cache(cur)
+                root_table_name = self.add_table_mapping(cur, (stream_buffer.stream,), {})
+                current_table_schema = self.get_table_schema(cur, None, root_table_name)
 
-                if not table_metadata:
+                if not current_table_schema:
                     self.LOGGER.error('{} - Table for stream does not exist'.format(
                         stream_buffer.stream))
-                elif table_metadata.get('version') is not None and table_metadata.get('version') >= version:
+                elif current_table_schema.get('version') is not None and current_table_schema.get('version') >= version:
                     self.LOGGER.warning('{} - Table version {} already active'.format(
                         stream_buffer.stream,
                         version))
                 else:
-                    versioned_root_table = stream_buffer.stream + SEPARATOR + str(version)
+                    versioned_root_table = root_table_name + SEPARATOR + str(version)
+
+                    names_to_paths = dict([(v, k) for k, v in self.table_mapping_cache.items()])
 
                     cur.execute(
                         sql.SQL('''
@@ -217,7 +245,8 @@ class PostgresTarget(SQLInterface):
                             sql.Literal(versioned_root_table + '%')))
 
                     for versioned_table_name in map(lambda x: x[0], cur.fetchall()):
-                        table_name = stream_buffer.stream + versioned_table_name[len(versioned_root_table):]
+                        table_name = root_table_name + versioned_table_name[len(versioned_root_table):]
+                        table_path = names_to_paths[table_name]
                         cur.execute(
                             sql.SQL('''
                             ALTER TABLE {table_schema}.{stream_table} RENAME TO {stream_table_old};
@@ -230,6 +259,15 @@ class PostgresTarget(SQLInterface):
                                                                 'old'),
                                 stream_table=sql.Identifier(table_name),
                                 version_table=sql.Identifier(versioned_table_name)))
+                        metadata = self._get_table_metadata(cur, table_name)
+
+                        self.LOGGER.info('Activated {}, setting path to {}'.format(
+                            metadata,
+                            table_path
+                        ))
+
+                        metadata['path'] = table_path
+                        self._set_table_metadata(cur, table_name, metadata)
             except Exception as ex:
                 cur.execute('ROLLBACK;')
                 message = '{} - Exception activating table version {}'.format(
@@ -281,7 +319,7 @@ class PostgresTarget(SQLInterface):
             metadata['key_properties'] = key_properties
             self._set_table_metadata(cur, table_name, metadata)
 
-    def add_table(self, cur, name, metadata):
+    def add_table(self, cur, path, name, metadata):
         self._validate_identifier(name)
 
         create_table_sql = sql.SQL('CREATE TABLE {}.{}').format(
@@ -290,43 +328,25 @@ class PostgresTarget(SQLInterface):
 
         cur.execute(sql.SQL('{} ();').format(create_table_sql))
 
-        self._set_table_metadata(cur, name, {'version': metadata.get('version', None),
+        self._set_table_metadata(cur, name, {'path': path,
+                                             'version': metadata.get('version', None),
                                              'schema_version': metadata['schema_version']})
 
     def add_table_mapping(self, cur, from_path, metadata):
-        root_table = from_path[0]
-        cur.execute(
-            sql.SQL('''
-            SELECT EXISTS(
-              SELECT 1
-              FROM information_schema.tables
-              WHERE table_schema = {}
-                AND table_name = {}
-            );
-            ''').format(
-                sql.Literal(self.postgres_schema),
-                sql.Literal(root_table)))
+        root_path = (from_path[0],)
+        root_mapping = self.add_table_mapping_helper(root_path, root_path, self.table_mapping_cache)
 
         # No root table present
         ## Table mappings are hung off of the root table's metadata
         ## SQLInterface's helpers do not guarantee order of table creation
-        if not cur.fetchone()[0]:
-            self.add_table(cur, root_table, metadata)
+        if not root_mapping['exists']:
+            self.table_mapping_cache[root_path] = root_mapping['to']
 
-        metadata = self._get_table_metadata(cur, root_table)
-        if not metadata:
-            metadata = {}
-
-        if not 'table_mappings' in metadata:
-            metadata['table_mappings'] = []
-
-        mapping = self.add_table_mapping_helper(from_path, metadata['table_mappings'])
+        root_from_path = root_path + from_path[1:]
+        mapping = self.add_table_mapping_helper(from_path, root_from_path, self.table_mapping_cache)
 
         if not mapping['exists']:
-            metadata['table_mappings'].append({'type': 'TABLE',
-                                               'from': from_path,
-                                               'to': mapping['to']})
-            self._set_table_metadata(cur, root_table, metadata)
+            self.table_mapping_cache[from_path] = mapping['to']
 
         return mapping['to']
 
@@ -644,19 +664,9 @@ class PostgresTarget(SQLInterface):
         if metadata is None:
             metadata = {'version': None}
 
-        if len(path) > 1:
-            table_mappings = self.get_table_schema(cur, path[:1], path[0])['table_mappings']
-        else:
-            table_mappings = []
-            for mapping in metadata.get('table_mappings', []):
-                if mapping['type'] == 'TABLE':
-                    table_mappings.append(mapping)
-
         metadata['name'] = name
-        metadata['path'] = path
         metadata['type'] = 'TABLE_SCHEMA'
         metadata['schema'] = {'properties': properties}
-        metadata['table_mappings'] = table_mappings
 
         if 0 == metadata.get('schema_version', 0):
             return _update_schema_0_to_1(metadata)

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -145,7 +145,7 @@ class PostgresTarget(SQLInterface):
                 self.setup_table_mapping_cache(cur)
 
                 root_table_name = self.add_table_mapping_helper((stream_buffer.stream,), self.table_mapping_cache)['to']
-                current_table_schema = self.get_table_schema(cur, None, root_table_name)
+                current_table_schema = self.get_table_schema(cur, root_table_name)
 
                 current_table_version = None
 
@@ -224,7 +224,7 @@ class PostgresTarget(SQLInterface):
 
                 self.setup_table_mapping_cache(cur)
                 root_table_name = self.add_table_mapping(cur, (stream_buffer.stream,), {})
-                current_table_schema = self.get_table_schema(cur, None, root_table_name)
+                current_table_schema = self.get_table_schema(cur, root_table_name)
 
                 if not current_table_schema:
                     self.LOGGER.error('{} - Table for stream does not exist'.format(
@@ -638,7 +638,7 @@ class PostgresTarget(SQLInterface):
 
         return cur.fetchall()[0][0] == 0
 
-    def get_table_schema(self, cur, path, name):
+    def get_table_schema(self, cur, name):
         cur.execute(
             sql.SQL('SELECT column_name, data_type, is_nullable FROM information_schema.columns ') +
             sql.SQL('WHERE table_schema = {} and table_name = {};').format(

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -142,7 +142,7 @@ class PostgresTarget(SQLInterface):
 
                 self.setup_table_mapping_cache(cur)
 
-                root_table_name = self.add_table_mapping(cur, (stream_buffer.stream,), {})
+                root_table_name = self.add_table_mapping_helper((stream_buffer.stream,), self.table_mapping_cache)['to']
                 current_table_schema = self.get_table_schema(cur, None, root_table_name)
 
                 current_table_version = None
@@ -184,6 +184,7 @@ class PostgresTarget(SQLInterface):
                     target_table_version
                 ))
 
+                root_table_name = stream_buffer.stream
                 if current_table_version is not None and \
                         stream_buffer.max_version is not None:
                     if stream_buffer.max_version < current_table_version:
@@ -198,7 +199,6 @@ class PostgresTarget(SQLInterface):
 
                 self.LOGGER.info('Root table name {}'.format(root_table_name))
 
-                self._validate_identifier(root_table_name)
                 written_batches_details = self.write_batch_helper(cur,
                                                                   root_table_name,
                                                                   stream_buffer.schema,
@@ -333,17 +333,7 @@ class PostgresTarget(SQLInterface):
                                              'schema_version': metadata['schema_version']})
 
     def add_table_mapping(self, cur, from_path, metadata):
-        root_path = (from_path[0],)
-        root_mapping = self.add_table_mapping_helper(root_path, root_path, self.table_mapping_cache)
-
-        # No root table present
-        ## Table mappings are hung off of the root table's metadata
-        ## SQLInterface's helpers do not guarantee order of table creation
-        if not root_mapping['exists']:
-            self.table_mapping_cache[root_path] = root_mapping['to']
-
-        root_from_path = root_path + from_path[1:]
-        mapping = self.add_table_mapping_helper(from_path, root_from_path, self.table_mapping_cache)
+        mapping = self.add_table_mapping_helper(from_path, self.table_mapping_cache)
 
         if not mapping['exists']:
             self.table_mapping_cache[from_path] = mapping['to']

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -120,17 +120,19 @@ class PostgresTarget(SQLInterface):
 
         cur.execute(
             sql.SQL('''
-                SELECT c.relname, CAST(obj_description(c.oid) AS json)->'path'
+                SELECT c.relname, obj_description(c.oid)
                 FROM pg_namespace AS n
                   INNER JOIN pg_class AS c ON n.oid = c.relnamespace
                 WHERE n.nspname = {};
                 ''').format(sql.Literal(self.postgres_schema)))
 
-        for column in cur.fetchall():
-            self.LOGGER.info("Mapping: {}".format(column))
-            if column[1]:
-                table_path = tuple(column[1])
-                self.table_mapping_cache[table_path] = column[0]
+        for mapped_name, raw_json in cur.fetchall():
+            table_path = None
+            if raw_json:
+                table_path = json.loads(raw_json).get('path', None)
+            self.LOGGER.info("Mapping: {} to {}".format(mapped_name, table_path))
+            if table_path:
+                self.table_mapping_cache[tuple(table_path)] = mapped_name
 
     def write_batch(self, stream_buffer):
         if not self.persist_empty_tables and stream_buffer.count == 0:

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -132,9 +132,6 @@ class PostgresTarget(SQLInterface):
         """
         Given a Cursor for a Postgres Connection, upgrade table schemas at version 0 to version 1.
 
-        NOTE: This transformation is purely informational. There is no _actual_ schema update that needs to happen,
-        nor any data migration.
-
         :param cur: Cursor
         :return: None
         """
@@ -165,9 +162,6 @@ class PostgresTarget(SQLInterface):
     def _update_schemas_1_to_2(self, cur):
         """
         Given a Cursor for a Postgres Connection, upgrade table schemas at version 1 to version 2.
-
-        NOTE: This transformation is purely informational. There is no _actual_ schema update that needs to happen,
-        nor any data migration.
 
         :param cur: Cursor
         :return: None

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -225,7 +225,7 @@ class SQLInterface:
         """
         raise NotImplementedError('`add_key_properties` not implemented.')
 
-    def add_table_mapping_helper(self, from_path, root_from_path, table_mappings):
+    def add_table_mapping_helper(self, from_path, table_mappings):
         """
 
         :param from_path:
@@ -239,7 +239,7 @@ class SQLInterface:
 
         to_from = dict([(v, k) for k, v in table_mappings.items()])
 
-        name = SEPARATOR.join(root_from_path)
+        name = SEPARATOR.join(from_path)
 
         raw_canonicalized_name = self.canonicalize_identifier(name)
         canonicalized_name = raw_canonicalized_name[:self.IDENTIFIER_FIELD_LENGTH]

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -22,7 +22,7 @@ from target_postgres import denest
 from target_postgres import json_schema
 
 SEPARATOR = '__'
-CURRENT_SCHEMA_VERSION = 1
+CURRENT_SCHEMA_VERSION = 2
 
 
 def _duration_millis(start):

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -89,30 +89,27 @@ class SQLInterface:
         """
         raise NotImplementedError('`` not implemented.')
 
-    def get_table_schema(self, connection, path, name):
+    def get_table_schema(self, connection, name):
         """
         Fetch the `table_schema` for `name`.
 
         :param connection: remote connection, type left to be determined by implementing class
-        :param path: (string, ...)
         :param name: string
         :return: TABLE_SCHEMA(remote)
         """
         raise NotImplementedError('`get_table_schema` not implemented.')
 
-    def _get_table_schema(self, connection, path, name):
+    def _get_table_schema(self, connection, name):
         """
         get_table_schema, but with checking the version of the schema to ensure latest format.
 
         :param connection: remote connection, type left to be determined by implementing class
-        :param path: (string, ...)
         :param name: string
         :return: TABLE_SCHEMA(remote)
         """
-        remote_schema = self.get_table_schema(connection, path, name)
+        remote_schema = self.get_table_schema(connection, name)
         if remote_schema and remote_schema.get('schema_version', 0) != CURRENT_SCHEMA_VERSION:
-            raise Exception('Schema for `{}` (`{}`) is of version {}. Expected version {}'.format(
-                path,
+            raise Exception('Schema for `{}` is of version {}. Expected version {}'.format(
                 name,
                 remote_schema.get('schema_version', 0),
                 CURRENT_SCHEMA_VERSION
@@ -383,11 +380,11 @@ class SQLInterface:
 
             self._set_metrics_tags__table(timer, table_name)
 
-            existing_schema = self._get_table_schema(connection, table_path, table_name)
+            existing_schema = self._get_table_schema(connection, table_name)
 
             if existing_schema is None:
                 self.add_table(connection, table_path, table_name, _metadata)
-                existing_schema = self._get_table_schema(connection, table_path, table_name)
+                existing_schema = self._get_table_schema(connection, table_name)
 
             self.add_key_properties(connection, table_name, schema.get('key_properties', None))
 
@@ -619,7 +616,7 @@ class SQLInterface:
 
                 log_message(upsert_table_helper__column)
 
-            return self._get_table_schema(connection, table_path, table_name)
+            return self._get_table_schema(connection, table_name)
 
     def _serialize_table_record_field_name(self, remote_schema, streamed_schema, path, value_json_schema):
         """

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -854,8 +854,7 @@ def test_loading__invalid__table_name__stream(db_cleanup):
         stream.schema = deepcopy(stream.schema)
         stream.schema['stream'] = stream_name
 
-        with pytest.raises(postgres.PostgresError, match=postgres_error_regex):
-            main(CONFIG, input_stream=stream)
+        main(CONFIG, input_stream=stream)
 
     invalid_stream_named('', r'.*non empty.*')
     invalid_stream_named('x' * 1000, r'Length.*')


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/issues/102

- Provide logic which works in `target-redshift` as well as `target-postgres`
  - works across all versions
- Migrates existing remote databases seamlessly
- Existing tests remain untouched

## Notes

This will break instances where _multiple_ versions of `target-postgres` are trying to upsert _different_ streams (taps) to the same remote.

I'm unsure as to whether we _want_ to support this use case.

ie, as a user, I have a long running tap persisting data to postgres db A, via `target-postgres v0.1.8`. I also want to be able to run the latest `target-postgres v0.1.X` to persist another `tap` to db A.

## Suggested Musical Pairing

https://soundcloud.com/snottynoserezkids/sets/snotty-nose-rez-kids-lp