### PR TITLE
Fix/activate version not flushing buffer

### DIFF
--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -13,7 +13,6 @@ from target_postgres.exceptions import TargetError
 from target_postgres.singer_stream import BufferedSingerStream
 from target_postgres.stream_tracker import StreamTracker
 
-
 LOGGER = singer.get_logger()
 
 
@@ -61,7 +60,7 @@ def stream_to_target(stream, target, config={}):
                           max_batch_rows,
                           max_batch_size,
                           line
-            )
+                          )
             if line_count > 0 and line_count % batch_detection_threshold == 0:
                 state_tracker.flush_streams()
             line_count += 1
@@ -86,7 +85,8 @@ def _report_invalid_records(streams):
             ))
 
 
-def _line_handler(state_tracker, target, invalid_records_detect, invalid_records_threshold, max_batch_rows, max_batch_size, line):
+def _line_handler(state_tracker, target, invalid_records_detect, invalid_records_threshold, max_batch_rows,
+                  max_batch_size, line):
     try:
         line_data = json.loads(line)
     except json.decoder.JSONDecodeError:
@@ -146,6 +146,7 @@ def _line_handler(state_tracker, target, invalid_records_detect, invalid_records
 
         stream_buffer = state_tracker.streams[line_data['stream']]
         target.write_batch(stream_buffer)
+        state_tracker.flush_stream(line_data['stream'])
         target.activate_version(stream_buffer, line_data['version'])
     elif line_data['type'] == 'STATE':
         state_tracker.handle_state_message(line_data)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -486,3 +486,21 @@ def db_cleanup():
     yield
 
     clear_db()
+
+class ListStream:
+    idx = None
+    stream = NotImplementedError()
+
+    def __init__(self):
+        self.idx = -1
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.idx += 1
+
+        if self.idx < len(self.stream):
+            return json.dumps(self.stream[self.idx])
+
+        raise StopIteration

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -4,7 +4,7 @@ import psycopg2
 import psycopg2.extras
 import pytest
 
-from fixtures import CONFIG, db_cleanup, TEST_DB
+from fixtures import CONFIG, db_cleanup, ListStream, TEST_DB
 from target_postgres import main
 
 
@@ -33,26 +33,7 @@ def assert_count_equal(cursor, table_name, n):
     assert cursor.fetchone()[0] == n
 
 
-class SandboxStream:
-    idx = None
-    stream = NotImplementedError()
-
-    def __init__(self):
-        self.idx = -1
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        self.idx += 1
-
-        if self.idx < len(self.stream):
-            return json.dumps(self.stream[self.idx])
-
-        raise StopIteration
-
-
-class BigCommerceStream(SandboxStream):
+class BigCommerceStream(ListStream):
     stream = [
         {"type": "SCHEMA",
          "stream": "products",
@@ -377,7 +358,7 @@ def test_bigcommerce__sandbox(db_cleanup):
                                  })
 
 
-class HubspotStream(SandboxStream):
+class HubspotStream(ListStream):
     stream = [
         {"type": "SCHEMA",
          "stream": "deals",

--- a/tests/test_target_tools.py
+++ b/tests/test_target_tools.py
@@ -80,8 +80,8 @@ def test_loading__invalid__records__threshold():
 
 def test_state__capture(capsys):
     stream = [
-        json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }}),
-        json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})]
+        json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}}),
+        json.dumps({'type': 'STATE', 'value': {'test': 'state-2'}})]
 
     target_tools.stream_to_target(stream, Target())
     output = filtered_output(capsys)
@@ -93,8 +93,8 @@ def test_state__capture(capsys):
 
 def test_state__capture_can_be_disabled(capsys):
     stream = [
-        json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }}),
-        json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})]
+        json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}}),
+        json.dumps({'type': 'STATE', 'value': {'test': 'state-2'}})]
 
     target_tools.stream_to_target(stream, Target(), {'state_support': False})
     output = filtered_output(capsys)
@@ -113,13 +113,13 @@ def test_state__emits_only_messages_when_all_records_before_have_been_flushed(ca
         yield rows[0]
         for row in rows[slice(1, 5)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}})
         for row in rows[slice(6, 10)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-2'}})
         for row in rows[slice(11, 15)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-3' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-3'}})
 
         # After some state messages but before the batch size has been hit no state messages should have been emitted
         assert len(target.calls['write_batch']) == 0
@@ -128,7 +128,7 @@ def test_state__emits_only_messages_when_all_records_before_have_been_flushed(ca
 
         for row in rows[slice(16, 25)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-4' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-4'}})
 
         # After the batch size has been hit and a write_batch call was made, the most recent safe to emit state should have been emitted
         assert len(target.calls['write_batch']) == 1
@@ -152,7 +152,7 @@ def test_state__emits_most_recent_state_when_final_flush_occurs(capsys):
     config['max_batch_rows'] = 20
     config['batch_detection_threshold'] = 1
     rows = list(CatStream(5))
-    rows.append(json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }}))
+    rows.append(json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}}))
 
     target_tools.stream_to_target(rows, Target(), config=config)
 
@@ -188,15 +188,15 @@ def test_state__doesnt_emit_when_only_one_of_several_streams_is_flushing(capsys)
             yield row
         for row in dog_rows[slice(1, 5)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}})
 
         for row in cat_rows[slice(6, 45)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-2' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-2'}})
 
         for row in cat_rows[slice(46, 65)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-3' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-3'}})
 
         # After some state messages but before the batch size has been hit for both streams no state messages should have been emitted
         assert len(target.calls['write_batch']) == 3
@@ -205,7 +205,7 @@ def test_state__doesnt_emit_when_only_one_of_several_streams_is_flushing(capsys)
 
         for row in dog_rows[slice(6, 25)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-4' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-4'}})
 
         # After the batch size has been hit and a write_batch call was made, the most recent safe to emit state should have been emitted
         assert len(target.calls['write_batch']) == 4
@@ -232,13 +232,13 @@ def test_state__doesnt_emit_when_it_isnt_different_than_the_previous_emission(ca
         yield rows[0]
         for row in rows[slice(1, 21)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}})
         output = filtered_output(capsys)
         assert len(output) == 1
 
         for row in rows[slice(22, 99)]:
             yield row
-        yield json.dumps({'type': 'STATE', 'value': { 'test': 'state-1' }})
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}})
 
         output = filtered_output(capsys)
         assert len(output) == 0

--- a/tests/test_target_tools.py
+++ b/tests/test_target_tools.py
@@ -22,7 +22,7 @@ class Target(SQLInterface):
         return None
 
     def activate_version(self, stream_buffer, version):
-        self.calls['activate_version'] += 1
+        self.calls['activate_version'].append({'records_count': len(stream_buffer.peek_buffer())})
         return None
 
 


### PR DESCRIPTION
# Motivation

When we issue an activate version record, we presently do not flush the buffer after writing the batch. This results in more records being written to remote than need to be.

## Suggested Musical Pairing

https://soundcloud.com/kaytranada/weight-off