### PR TITLE
Emit STATE values to stdout instead of the whole state message

### DIFF
--- a/target_postgres/stream_tracker.py
+++ b/target_postgres/stream_tracker.py
@@ -50,9 +50,9 @@ class StreamTracker:
 
         self._emit_safe_queued_states(force=force)
 
-    def handle_state_message(self, value):
+    def handle_state_message(self, line_data):
         if self.emit_states:
-            self.state_queue.append({'state': value, 'watermark': self.message_counter})
+            self.state_queue.append({'state': line_data['value'], 'watermark': self.message_counter})
             self._emit_safe_queued_states()
 
     def handle_record_message(self, stream, line_data):

--- a/tests/unit/test_target_tools.py
+++ b/tests/unit/test_target_tools.py
@@ -124,8 +124,8 @@ def test_state__capture(capsys):
     output = filtered_output(capsys)
 
     assert len(output) == 2
-    assert json.loads(output[0])['value']['test'] == 'state-1'
-    assert json.loads(output[1])['value']['test'] == 'state-2'
+    assert json.loads(output[0])['test'] == 'state-1'
+    assert json.loads(output[1])['test'] == 'state-2'
 
 
 def test_state__capture_can_be_disabled(capsys):
@@ -171,7 +171,7 @@ def test_state__emits_only_messages_when_all_records_before_have_been_flushed(ca
         assert len(target.calls['write_batch']) == 1
         output = filtered_output(capsys)
         assert len(output) == 1
-        assert json.loads(output[0])['value']['test'] == 'state-3'
+        assert json.loads(output[0])['test'] == 'state-3'
 
         for row in rows[slice(26, 31)]:
             yield row
@@ -181,7 +181,7 @@ def test_state__emits_only_messages_when_all_records_before_have_been_flushed(ca
     # The final state message should have been outputted after the last records were loaded
     output = filtered_output(capsys)
     assert len(output) == 1
-    assert json.loads(output[0])['value']['test'] == 'state-4'
+    assert json.loads(output[0])['test'] == 'state-4'
 
 
 def test_state__emits_most_recent_state_when_final_flush_occurs(capsys):
@@ -197,7 +197,7 @@ def test_state__emits_most_recent_state_when_final_flush_occurs(capsys):
     # one full flushable batch
     output = filtered_output(capsys)
     assert len(output) == 1
-    assert json.loads(output[0])['value']['test'] == 'state-1'
+    assert json.loads(output[0])['test'] == 'state-1'
 
 
 class DogStream(CatStream):
@@ -248,14 +248,14 @@ def test_state__doesnt_emit_when_only_one_of_several_streams_is_flushing(capsys)
         assert len(target.calls['write_batch']) == 4
         output = filtered_output(capsys)
         assert len(output) == 1
-        assert json.loads(output[0])['value']['test'] == 'state-2'
+        assert json.loads(output[0])['test'] == 'state-2'
 
     target_tools.stream_to_target(test_stream(), target, config=config)
 
     # The final state message should have been outputted after the last dog records were loaded despite not reaching one full flushable batch
     output = filtered_output(capsys)
     assert len(output) == 1
-    assert json.loads(output[0])['value']['test'] == 'state-4'
+    assert json.loads(output[0])['test'] == 'state-4'
 
 
 def test_state__doesnt_emit_when_it_isnt_different_than_the_previous_emission(capsys):


### PR DESCRIPTION
This fixes https://github.com/datamill-co/target-postgres/issues/141 and should improve https://gitlab.com/meltano/meltano/issues/884.

Before this change, target-postgres worked slightly differently than the other taps out there and wrote incoming STATE messages to stdout as the full content of the mesage, including the `{"value": ...}` wrapper around the opaque STATE JSON. Other taps, including the official `singer-target-template`, don't write out that `value` wrapper, and just write the JSON blob contained in it.

This brings target-postgres inline with the other targets and the defacto rule.