### PR TITLE
Add the migrations test setup script to the docker entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 python -m venv venv/target-postgres
+tests/migrations/scripts/install_schema_versions.sh
 source /code/venv/target-postgres/bin/activate
 
 pip install -e .[tests]


### PR DESCRIPTION
The new migrations test requires a couple more virtualenvs to be setup for the test to run correctly. This is handily automated in a setup script, but prior to this change developers had to know the script existed and run it themselves to get their development environment to run the tests successfully.

This changes the development environment setup script to run the migrations test setup script as well so the tests should run cleanly from the very beginning of A Developer's Journey.

An alternative to this approach might be building a whole development docker image with a `Dockerfile` that does the same stuff. This would be better because the setup would only happen once and then those layers cached, instead of this approach which will run the setup each time the container is booted. I think that's fine though -- it's not that often and I think this project doesn't have a gazillion contributors such that lots investment in the development infrastructure is necessary. It's also good that the script remains separate so that developers not running inside docker-compose could still execute it perhaps. 