### PR TITLE
Pre-release: Changelog and version bump for v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.11
+
+- **BUG FIX:** `canonicalize_identifier` Not called on _all_ identifiers persisted to remote
+  - [FIX LINK](https://github.com/datamill-co/target-postgres/pull/144)
+  - Presently, on column splits/name collisions, we add a suffix to an identifier
+  - Previously, we did not canonicalize these suffixes
+  - While this was not an issue for any `targets` currently in production, it was an issue
+    for some up and coming `targets`.
+  - This fix simply makes sure to call `canonicalize_identifier` before persisting an identifier to remote
+
 ## 0.1.10
 
 - **FEATURES:**

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name='singer-target-postgres',
     url='https://github.com/datamill-co/target-postgres',
     author='datamill',
-    version="0.1.10",
+    version="0.1.11",
     description='Singer.io target for loading data into postgres',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Motivation

Prep for release of bugfixes to be able to continue development on downstream targets.