### PR TITLE
Emit STATE messages if only one of many registered streams is adding records

### DIFF
--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -145,7 +145,6 @@ def _line_handler(state_tracker, target, invalid_records_detect, invalid_records
                               .format(line_data['stream']))
 
         stream_buffer = state_tracker.streams[line_data['stream']]
-        target.write_batch(stream_buffer)
         state_tracker.flush_stream(line_data['stream'])
         target.activate_version(stream_buffer, line_data['version'])
     elif line_data['type'] == 'STATE':

--- a/tests/unit/test_target_tools.py
+++ b/tests/unit/test_target_tools.py
@@ -8,7 +8,7 @@ from target_postgres import singer_stream
 from target_postgres import target_tools
 from target_postgres.sql_base import SQLInterface
 
-from utils.fixtures import CONFIG, CatStream, ListStream, InvalidCatStream
+from utils.fixtures import CONFIG, CatStream, ListStream, InvalidCatStream, DogStream
 
 
 class Target(SQLInterface):
@@ -198,14 +198,6 @@ def test_state__emits_most_recent_state_when_final_flush_occurs(capsys):
     output = filtered_output(capsys)
     assert len(output) == 1
     assert json.loads(output[0])['test'] == 'state-1'
-
-
-class DogStream(CatStream):
-    stream = 'dogs'
-    schema = CatStream.schema.copy()
-
-
-DogStream.schema['stream'] = 'dogs'
 
 
 def test_state__doesnt_emit_when_only_one_of_several_streams_is_flushing(capsys):

--- a/tests/unit/test_target_tools.py
+++ b/tests/unit/test_target_tools.py
@@ -258,6 +258,42 @@ def test_state__doesnt_emit_when_only_one_of_several_streams_is_flushing(capsys)
     assert json.loads(output[0])['test'] == 'state-4'
 
 
+def test_state__emits_when_multiple_streams_are_registered_but_records_arrive_from_only_one(capsys):
+    config = CONFIG.copy()
+    config['max_batch_rows'] = 20
+    config['batch_detection_threshold'] = 1
+    cat_rows = list(CatStream(100))
+    dog_rows = list(DogStream(50))
+    target = Target()
+
+    # Simulate one stream that yields a lot of records with another that yields no records, and ensure that only the first
+    # needs to be flushed before any state messages are emitted
+    def test_stream():
+        yield cat_rows[0]
+        yield dog_rows[0]
+        for row in cat_rows[slice(1, 5)]:
+            yield row
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}})
+
+        for row in cat_rows[slice(6, 25)]:
+            yield row
+        yield json.dumps({'type': 'STATE', 'value': {'test': 'state-2'}})
+
+        # After some state messages and only one of the registered streams has hit the batch size, the state message should be emitted, as there are no unflushed records from the other stream yet
+        assert len(target.calls['write_batch']) == 1
+        output = filtered_output(capsys)
+        assert len(output) == 1
+        assert json.loads(output[0])['test'] == 'state-1'
+
+
+    target_tools.stream_to_target(test_stream(), target, config=config)
+
+    # The final state message should have been outputted after the last dog records were loaded despite not reaching one full flushable batch
+    output = filtered_output(capsys)
+    assert len(output) == 1
+    assert json.loads(output[0])['test'] == 'state-2'
+
+
 def test_state__doesnt_emit_when_it_isnt_different_than_the_previous_emission(capsys):
     config = CONFIG.copy()
     config['max_batch_rows'] = 5

--- a/tests/utils/fixtures.py
+++ b/tests/utils/fixtures.py
@@ -505,3 +505,11 @@ class ListStream:
             return json.dumps(self.stream[self.idx])
 
         raise StopIteration
+
+
+class DogStream(CatStream):
+    stream = 'dogs'
+    schema = CatStream.schema.copy()
+
+
+DogStream.schema['stream'] = 'dogs'


### PR DESCRIPTION
This fixes a small but annoying bug in the STATE message support for taps that output records to many streams at once, and especially taps that emit a whole whack of schemas at the start of the run, and then emit all the records for each stream one by one.

Before this change, the safe-to-emit-STATE-message watermark was the global minimum of each stream's most recently flushed watermark. This works well when you have many streams emitting records at once due to the whole "don't know which streams each STATE message covers so we have to be sure all records from before the STATE message was emitted have been flushed before passing along the STATE message" thing. The add watermark rises higher than the flushed watermark as records are buffered, and then the flush watermark catches up when a flush happens, moving the global minimum up and permitting new STATE messages to be emitted.

Before this change, upon receiving a SCHEMA message for a new stream, the stream is registered, and a most recently added and most recently flushed watermark of 0 is set for that stream. That makes sense because no records for that stream have been added yet, so no records have been flushed yet, so the flush watermark is set to the same thing that the add watermark is. All the SCHEMA message sets up is an expectation for what records might (or might not ever) come. For the purposes of emitting STATE messages, the SCHEMA message doesn't really hold any value, as STATE is really only relative to records.

So, the issue is that the previous version of this code initialized each stream's most recently flushed watermark to 0 upon receiving the SCHEMA message, which locked the global minimum flush watermark at 0 until any records for that stream arrived. If the tap works in such a way that it moves through each stream making API calls for that stream, this means that until the very last stream is processed, that stream's flush watermark at 0, as no records have been flushed yet, but that also means the global flush watermark is at 0 too. This leads to no state messages being output until the end. D'oh.

This changes things around in the tracker class to not include streams who haven't yet seen records to not be included in the global threshold calculation. This has the effect of allowing straightforward initialization on SCHEMA messages while allowing streams to be processed incrementally and STATE messages to be emitted without including not-yet-in-use streams. The code to do this is pretty verbose because the issues are subtle, so I've tried to comment a bit more than usual and be explicit.

I'm a little concerned about this whole thing as I think this is beginning to violate the KISS rule. I try to abide by the whole "write code only as half as smart as you are because you need to be twice as smart as the code to debug it", and, based on the amount of issues coming out of this, it would appear I am at the limits of my smartness. If anyone has suggestions for a simpler approach or a better testing strategy I am all ears! Also happy to provide more context or examples to make reviewing a bit easier. Of note is that I was able to TDD this fix and write the failing test first, then apply this fix to fix the test unchanged.