### PR TITLE
Feature/all of support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ _The above is copied from the [current list of versions](https://www.postgresql.
     - `['integer', 'number']`
     - `['any']`
     - `['null']`
-- JSON Schema combinations such as `anyOf` and `allOf` are not supported.
+- JSON Schema combinations such as `anyOf` and `oneOf` are not supported.
 - JSON Schema \$ref is partially supported:
   - **_NOTE:_** The following limitations are known to **NOT** fail gracefully
   - Presently you cannot have any circular or recursive `$ref`s

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -42,14 +42,14 @@ def get_type(schema):
     :param schema: dict, JSON Schema
     :return: [string ...]
     """
-    type = schema.get('type', None)
-    if not type:
+    _type = schema.get('type', None)
+    if not _type:
         return [OBJECT]
 
-    if isinstance(type, str):
-        return [type]
+    if isinstance(_type, str):
+        return [_type]
 
-    return type
+    return _type
 
 
 def simple_type(schema):
@@ -67,13 +67,13 @@ def simple_type(schema):
     :param schema: dict, JSON Schema
     :return: dict, JSON Schema
     """
-    type = get_type(schema)
+    _type = get_type(schema)
 
     if is_datetime(schema):
-        return {'type': type,
+        return {'type': _type,
                 'format': DATE_TIME_FORMAT}
 
-    return {'type': type}
+    return {'type': _type}
 
 
 def _get_ref(schema, paths):
@@ -103,7 +103,7 @@ def get_ref(schema, ref):
                     re.split('/', re.sub(r'^#/', '', ref)))
 
 
-def is_ref(schema):
+def _is_ref(schema):
     """
     Given a JSON Schema compatible dict, returns True when the schema implements `$ref`
 
@@ -122,7 +122,7 @@ def is_object(schema):
     :return: Boolean
     """
 
-    return not is_ref(schema) \
+    return not _is_ref(schema) \
            and (OBJECT in get_type(schema)
                 or 'properties' in schema
                 or not schema)
@@ -135,7 +135,7 @@ def is_iterable(schema):
     :return: Boolean
     """
 
-    return not is_ref(schema) \
+    return not _is_ref(schema) \
            and ARRAY in get_type(schema) \
            and 'items' in schema
 
@@ -190,7 +190,7 @@ def _helper_simplify(root_schema, child_schema):
     ret_schema = {}
 
     ## Refs override all other type definitions
-    if is_ref(child_schema):
+    if _is_ref(child_schema):
         try:
             ret_schema = _helper_simplify(root_schema, get_ref(root_schema, child_schema['$ref']))
         except RecursionError:

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -62,7 +62,9 @@ class BufferedSingerStream():
         # In order to determine whether a value _is in_ properties _or not_ we need to flatten `$ref`s etc.
         self.schema = json_schema.simplify(schema)
         self.key_properties = deepcopy(key_properties)
-        self.validator = Draft4Validator(self.schema, format_checker=FormatChecker())
+
+        # The validator can handle _many_ more things than our simplified schema, and is, in general handled by third party code
+        self.validator = Draft4Validator(schema, format_checker=FormatChecker())
 
         properties = self.schema['properties']
 

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -45,8 +45,9 @@ def test_is_iterable():
 
 
 def test_is_nullable():
-    assert json_schema.is_iterable({'type': ['array', 'null'], 'items': {'type': ['boolean']}})
-    assert not json_schema.is_iterable({'type': ['string']})
+    assert json_schema.is_nullable({'type': ['array', 'null'], 'items': {'type': ['boolean']}})
+    assert json_schema.is_nullable({'type': ['integer', 'null']})
+    assert not json_schema.is_nullable({'type': ['string']})
     assert not json_schema.is_nullable({})
 
 

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -88,6 +88,55 @@ def test_simplify__empty_becomes_object():
     assert json_schema.simplify({}) == {'properties': {}, 'type': ['object']}
 
 
+def test_simplify__allOf__datetime():
+    assert json_schema.is_datetime(json_schema.simplify(
+        {'allOf': [{'type': 'string'}, {'type': 'string', 'format': 'date-time'}]}
+    ))
+
+    assert \
+        json_schema.simplify({
+            'allOf': [{'type': 'number'}, {'type': 'string', 'format': 'date-time'}]
+        }) \
+        == {'type': ['string'], 'format': 'date-time'}
+
+
+def test_simplify__allOf__nullable():
+    assert json_schema.is_nullable(json_schema.simplify(
+        {'allOf': [{'type': ['integer']}, {'type': ['string', 'null']}]}
+    ))
+
+
+def test_simplify__allOf__objects():
+    assert json_schema.is_object(json_schema.simplify(
+        {'allOf': [{'type': ['object']}]}
+    ))
+
+
+def test_simplify__allOf__iterables():
+    assert json_schema.is_iterable(json_schema.simplify(
+        {'allOf': [{'type': 'array', 'items': {'type': 'integer'}}]}
+    ))
+
+
+def test_simplify__allOf__picks_scalars():
+    assert \
+        json_schema.simplify({
+            'allOf': [
+                {},
+                {'type': 'integer'},
+                {'type': 'array', 'items': {'type': 'number'}}]
+        }) \
+        == {'type': ['integer']}
+
+    assert \
+        json_schema.simplify({
+            "allOf": [
+                { "type": "string" },
+                { "maxLength": 5 }
+            ]}) \
+        == {'type': ['string']}
+
+
 def test_simplify__types_into_arrays():
     assert \
         json_schema.simplify(
@@ -294,6 +343,40 @@ def test_simplify__refs():
                         'street_address': {'type': ['string']},
                         'city': {'type': ['string']},
                         'state': {'type': ['string']}}}}}
+
+    assert json_schema.simplify(
+        {
+            "definitions": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "street_address": { "type": "string" },
+                        "city": { "type": "string" },
+                        "state": { "type": "string" }
+                    },
+                    "required": ["street_address", "city", "state"]
+                }
+            },
+
+            "allOf": [
+                { "$ref": "#/definitions/address" },
+                { "properties": {
+                    "state": {'type': ['integer']},
+                    "extra": { "type": ["string"] }
+                    }
+                }
+            ]
+        }) \
+        == {
+            'type': ['object'],
+            "properties": {
+                    "street_address": { "type": ["string"] },
+                    "city": { "type": ["string"] },
+                    "state": {'type': ['integer']},
+                    "extra": { "type": ["string"] }
+                }
+            }
+        # NOTE: Objects get merged together by simplify
 
 
 def test_simplify__refs__invalid_format():


### PR DESCRIPTION
# Motivation

#14 

This pr seeks to add _full_ support for `allOf` to `Target-Postgres`.

This is done in a couple ways:
- validation of _all records_ against the raw schema (not our simplified one)
  - we assume that _impossible_ schemas will simply error violently here and thus we don't need to check for them later on
- simplification of the schema does a few things for `allOf`:
  - prefer datetimes
  - prefer literals
  - nullables break ties
  - merge all objects together
  - recurse (includes support for `$ref`s in `allOf`!)