### PR TITLE
Feature/any of support

### DIFF
--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -124,8 +124,8 @@ def _denest_schema_helper(table_path,
                              level + 1)
 
         if json_schema.is_literal(item_json_schema):
-            if nullable and not json_schema.is_nullable(item_json_schema):
-                item_json_schema['type'].append('null')
+            if nullable:
+                item_json_schema = json_schema.make_nullable(item_json_schema)
 
             top_level_schema[prop_path + (prop,)] = _literal_only_schema(item_json_schema)
 

--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -72,18 +72,29 @@ def _to_table_schema(path, level, keys, properties):
 
 
 def _literal_only_schema(schema):
-    ret = deepcopy(schema)
 
-    ret_type = json_schema.get_type(ret)
+    ret_types = json_schema.get_type(schema)
 
-    if json_schema.is_object(ret):
-        ret_type.remove(json_schema.OBJECT)
-    if json_schema.is_iterable(ret):
-        ret_type.remove(json_schema.ARRAY)
+    if json_schema.is_object(schema):
+        ret_types.remove(json_schema.OBJECT)
+    if json_schema.is_iterable(schema):
+        ret_types.remove(json_schema.ARRAY)
+    if json_schema.is_nullable(schema):
+        ret_types.remove(json_schema.NULL)
 
-    ret['type'] = ret_type
+    ret_schemas = []
+    for t in ret_types:
+        s = deepcopy(schema)
+        s['type'] = [t]
 
-    return ret
+        if json_schema.is_nullable(schema):
+            s = json_schema.make_nullable(s)
+
+        ret_schemas.append(s)
+
+    return {
+        'anyOf': ret_schemas
+    }
 
 
 def _denest_schema_helper(table_path,

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -229,19 +229,7 @@ class Cachable(dict):
 
     def _comparator(self):
         if not self._c:
-            item_c = tuple()
-            if is_iterable(self):
-                item_c = self['items']._comparator()
-
-            props_c = tuple()
-            if is_object(self):
-                props_c = tuple(sorted(self.get('properties', {}).items()))
-
-            self._c = (
-                tuple(sorted(get_type(self))),
-                self.get('format', ''),
-                item_c,
-                props_c)
+            self._c = json.dumps(self, sort_keys=True)
 
         return self._c
 

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -42,14 +42,14 @@ def get_type(schema):
     :param schema: dict, JSON Schema
     :return: [string ...]
     """
-    _type = schema.get('type', None)
-    if not _type:
+    t = schema.get('type', None)
+    if not t:
         return [OBJECT]
 
-    if isinstance(_type, str):
-        return [_type]
+    if isinstance(t, str):
+        return [t]
 
-    return _type
+    return deepcopy(t)
 
 
 def simple_type(schema):
@@ -67,13 +67,13 @@ def simple_type(schema):
     :param schema: dict, JSON Schema
     :return: dict, JSON Schema
     """
-    _type = get_type(schema)
+    t = get_type(schema)
 
     if is_datetime(schema):
-        return {'type': _type,
+        return {'type': t,
                 'format': DATE_TIME_FORMAT}
 
-    return {'type': _type}
+    return {'type': t}
 
 
 def _get_ref(schema, paths):
@@ -189,12 +189,12 @@ def make_nullable(schema):
     `is_nullable` will return true on the output.
     :return: dict, JSON Schema
     """
-    type = get_type(schema)
-    if NULL in type:
+    t = get_type(schema)
+    if NULL in t:
         return schema
 
     ret_schema = deepcopy(schema)
-    ret_schema['type'] = type + [NULL]
+    ret_schema['type'] = t + [NULL]
     return ret_schema
 
 
@@ -361,8 +361,8 @@ _shorthand_mapping = {
 def _type_shorthand(type_s):
     if isinstance(type_s, list):
         shorthand = ''
-        for type in sorted(type_s):
-            shorthand += _type_shorthand(type)
+        for t in sorted(type_s):
+            shorthand += _type_shorthand(t)
         return shorthand
 
     if not type_s in _shorthand_mapping:
@@ -375,10 +375,10 @@ def _type_shorthand(type_s):
 
 
 def shorthand(schema):
-    _type = deepcopy(get_type(schema))
+    t = deepcopy(get_type(schema))
 
-    if 'format' in schema and 'date-time' == schema['format'] and STRING in _type:
-        _type.remove(STRING)
-        _type.append('date-time')
+    if 'format' in schema and 'date-time' == schema['format'] and STRING in t:
+        t.remove(STRING)
+        t.append('date-time')
 
-    return _type_shorthand(_type)
+    return _type_shorthand(t)

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import json
 import re
 
 from jsonschema import Draft4Validator
@@ -117,26 +118,24 @@ def _is_ref(schema):
 
 def _is_allof(schema):
     """
-    Given a JSON Schema compatible dict, returns True when the schema implements `allOf`,
-    AND has allOf elements.
+    Given a JSON Schema compatible dict, returns True when the schema implements `allOf`.
 
     :param schema:
     :return: Boolean
     """
 
-    return not _is_ref(schema) and 'allOf' in schema and schema['allOf']
+    return not _is_ref(schema) and 'allOf' in schema
 
 
 def is_anyof(schema):
     """
-    Given a JSON Schema compatible dict, returns True when the schema implements `anyOf`,
-    AND has `anyOf` elements.
+    Given a JSON Schema compatible dict, returns True when the schema implements `anyOf`.
 
     :param schema:
     :return: Boolean
     """
 
-    return not _is_ref(schema) and not _is_allof(schema) and 'anyOf' in schema and schema['anyOf']
+    return not _is_ref(schema) and not _is_allof(schema) and 'anyOf' in schema
 
 
 def is_object(schema):
@@ -182,7 +181,7 @@ def is_literal(schema):
     :return: Boolean
     """
 
-    return not {STRING, INTEGER, NUMBER, BOOLEAN, NULL}.isdisjoint(set(get_type(schema)))
+    return not {STRING, INTEGER, NUMBER, BOOLEAN}.isdisjoint(set(get_type(schema)))
 
 
 def is_datetime(schema):
@@ -208,6 +207,43 @@ def make_nullable(schema):
     ret_schema = deepcopy(schema)
     ret_schema['type'] = t + [NULL]
     return ret_schema
+
+
+class Cachable(dict):
+    '''
+    The simplified json_schemas we produce are idempotent. ie, if you simplify a simplified
+    json_schema, it will return the same thing. We wrap the `dict` object with a few
+    helpers which extend it so that we avoid recursion in some instances.
+    '''
+    def __init__(self, raw_dict, simplified=True):
+        self.simplified = simplified
+        self._c = None
+        super(Cachable, self).__init__(self, **raw_dict)
+
+    def is_simplified(self):
+        return self.simplified
+
+    def __setitem__(self, key, value):
+        self.simplified = False
+        super(Cachable, self).__setitem__(key, value)
+
+    def __delitem__(self, key):
+        self.simplified = False
+        super(Cachable, self).__delitem__(key)
+
+    def __hash__(self):
+        if not self.is_simplified():
+            raise JSONSchemaError('A non simplified json_schema cannot be hashed.')
+
+        return json.dumps(self).__hash__()
+
+    def _comparator(self):
+        if not self._c:
+            self._c = (tuple(sorted(get_type(self))), self.__hash__())
+        return self._c
+
+    def __lt__(self, other):
+        return self._comparator() < other._comparator()
 
 
 def _allof_sort_key(schema):
@@ -243,8 +279,8 @@ def _simplify__allof__merge__objects(schemas):
     next_schemas = schemas[1:]
     while next_schemas and is_object(next_schemas[0]):
         ret_schema['properties'] = {
-            **ret_schema['properties'],
-            **next_schemas[0]['properties']}
+            **ret_schema.get('properties', {}),
+            **next_schemas[0].get('properties', {})}
 
         next_schemas = next_schemas[1:]
 
@@ -266,6 +302,23 @@ def _simplify__allof__merge__iterables(root_schema, schemas):
     return ret_schema
 
 
+def _simplify__allof(root_schema, child_schema):
+    simplified_schemas = [
+        _helper_simplify(root_schema, schema)
+        for schema in child_schema['allOf']]
+    schemas = sorted(simplified_schemas, key=_allof_sort_key)
+
+    ret_schema = schemas[0]
+
+    if is_object(ret_schema):
+        return _simplify__allof__merge__objects(schemas)
+
+    if is_iterable(ret_schema):
+        return _simplify__allof__merge__iterables(root_schema, schemas)
+
+    return ret_schema
+
+
 def _simplify__implicit_anyof(root_schema, schema):
     '''
     Typically literals are simple and have at most two types, one of which being NULL.
@@ -278,18 +331,18 @@ def _simplify__implicit_anyof(root_schema, schema):
     types = set(get_type(schema))
 
     if types == {NULL}:
-        raise JSONSchemaError('Cannot handle only `null` schema type.')
+        return Cachable({'type': [NULL]})
 
     types.discard(NULL)
 
     if is_datetime(schema):
-        schemas.append({
+        schemas.append(Cachable({
             'type': [STRING],
             'format': DATE_TIME_FORMAT
-        })
+        }))
 
         types.remove(STRING)
-    
+
     if is_object(schema):
         properties = {}
         for field, field_json_schema in schema.get('properties', {}).items():
@@ -301,7 +354,7 @@ def _simplify__implicit_anyof(root_schema, schema):
         })
 
         types.discard(OBJECT)
-    
+
     if is_iterable(schema):
         schemas.append({
             'type': [ARRAY],
@@ -310,48 +363,115 @@ def _simplify__implicit_anyof(root_schema, schema):
 
         types.remove(ARRAY)
 
-    # We sort the types here to make the result more reproducible. This aides testing
-    schemas += [{'type': [t]} for t in sorted(types)]
+    schemas += [{'type': [t]} for t in types]
 
     if is_nullable(schema):
         schemas = [make_nullable(s) for s in schemas]
 
-    if len(schemas) == 1:
-        return schemas[0]
 
-    # TODO: merge/simplify anyOf schemas
-    return {'anyOf': schemas}
+    return _helper_simplify(root_schema, {'anyOf': [Cachable(s) for s in schemas]})
 
 
-def _simplify__combinations(root_schema, schemas):
-    simplified_schemas = [
-        _helper_simplify(root_schema, schema)
-        for schema in schemas]
+def _simplify__anyof(root_schema, schema):
+    '''
+    `anyOf` clauses are merged/simplified according to the following rules (these _are_ recursive):
 
-    return sorted(simplified_schemas, key=_allof_sort_key)
+    - all literals are dedupped
+    - all objects are merged into the same object schema, with sub-schemas being grouped as simplified `anyOf` schemas
+    - all iterables' `items` schemas are merged as simplified `anyOf` schemas
+    - all `anyOf`s are flattened to the topmost
+    - if there is only a single element in an `anyOf`, that is denested
+    '''
+
+    schemas = [
+            _helper_simplify(root_schema, schema)
+            for schema in schema['anyOf']]
+
+    literals = set()
+    any_merged_objects = False
+    any_merged_objects_nullable = False
+    merged_object_properties = {}
+    any_merged_iters = False
+    any_merged_iters_nullable = False
+    merged_item_schemas = []
+
+    while schemas:
+        sub_schema = schemas.pop()
+
+        if is_literal(sub_schema):
+            literals.add(sub_schema)
+
+        elif is_anyof(sub_schema):
+            # Flatten potentially deeply nested `anyOf`s
+            schemas += sub_schema['anyOf']
+
+        elif is_object(sub_schema):
+            any_merged_objects = True
+            any_merged_objects_nullable = any_merged_objects_nullable or is_nullable(sub_schema)
+            for k, s in sub_schema.get('properties', {}).items():
+                if k in merged_object_properties:
+                    merged_object_properties[k].append(s)
+                else:
+                    merged_object_properties[k] = [s]
+
+        elif is_iterable(sub_schema):
+            any_merged_iters = True
+            any_merged_iters_nullable = any_merged_iters_nullable or is_nullable(sub_schema)
+            merged_item_schemas.append(sub_schema['items'])
+
+    merged_schemas = sorted(literals)
+
+    if any_merged_objects:
+        for k, v in merged_object_properties.items():
+            merged_object_properties[k] = _helper_simplify(root_schema, {'anyOf': v})
+
+        s = {
+            'type': [OBJECT],
+            'properties': merged_object_properties
+        }
+
+        if any_merged_objects_nullable:
+            s = make_nullable(s)
+
+        merged_schemas.append(Cachable(s))
+
+    if any_merged_iters:
+        merged_item_schemas = _helper_simplify(root_schema, {'anyOf': merged_item_schemas})
+
+        s = {
+            'type': [ARRAY],
+            'items': merged_item_schemas
+        }
+
+        if any_merged_iters_nullable:
+            s = make_nullable(s)
+
+        merged_schemas.append(Cachable(s))
+
+    if len(merged_schemas) == 1:
+        return merged_schemas[0]
+
+    return Cachable({'anyOf': merged_schemas})
 
 
 def _helper_simplify(root_schema, child_schema):
+    # We check this value to make simplify a noop for schemas which have _already_ been simplified
+    if isinstance(child_schema, Cachable) and child_schema.is_simplified():
+        return child_schema
+
     ## Refs override all other type definitions
     if _is_ref(child_schema):
         try:
             ret_schema = _helper_simplify(root_schema, get_ref(root_schema, child_schema['$ref']))
+
         except RecursionError:
             raise JSONSchemaError('`$ref` path "{}" is recursive'.format(get_ref(root_schema, child_schema['$ref'])))
 
     elif _is_allof(child_schema):
-        schemas = _simplify__combinations(root_schema, child_schema['allOf'])
-
-        ret_schema = schemas[0]
-
-        if is_object(ret_schema):
-            ret_schema = _simplify__allof__merge__objects(schemas)
-        elif is_iterable(ret_schema):
-            ret_schema = _simplify__allof__merge__iterables(root_schema, schemas)
+        ret_schema = _simplify__allof(root_schema, child_schema)
 
     elif is_anyof(child_schema):
-        # schemas = _simplify__combinations(root_schema, child_schema['anyOf'])
-        ret_schema = child_schema
+        ret_schema = _simplify__anyof(root_schema, child_schema)
 
     else:
         ret_schema = _simplify__implicit_anyof(root_schema, child_schema)
@@ -359,7 +479,7 @@ def _helper_simplify(root_schema, child_schema):
     if 'default' in child_schema:
         ret_schema['default'] = child_schema.get('default')
 
-    return ret_schema
+    return Cachable(ret_schema)
 
 
 def simplify(schema):

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -222,6 +222,11 @@ class Cachable(dict):
     def __hash__(self):
         return self._comparator().__hash__()
 
+    def deepcopy(self):
+        s = deepcopy(self)
+        s._c = self._c
+        return s
+
     def _comparator(self):
         if not self._c:
             item_c = tuple()
@@ -497,6 +502,8 @@ def simplify(schema):
     :return: dict, JSON Schema
     :raises: Exception
     """
+    if isinstance(schema, Cachable):
+        return schema.deepcopy()
 
     return _helper_simplify(schema, schema)
 

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -253,6 +253,17 @@ def _helper_simplify(root_schema, child_schema):
                     **next_schemas[0]['properties']}
 
                 next_schemas = next_schemas[1:]
+        elif is_iterable(ret_schema):
+            # Recurse on all of the item schemas to create a single item schema
+            item_schemas = []
+
+            next_schemas = schemas
+            while next_schemas and is_iterable(next_schemas[0]):
+                item_schemas.append(next_schemas[0]['items'])
+
+                next_schemas = next_schemas[1:]
+
+            ret_schema['items'] = _helper_simplify(root_schema, {'allOf': item_schemas})
 
     else:
 

--- a/target_postgres/singer.py
+++ b/target_postgres/singer.py
@@ -1,0 +1,12 @@
+'''
+Module for Singer literals and helpers.
+'''
+_PREFIX = '_sdc_'
+RECEIVED_AT =      _PREFIX + 'received_at'
+BATCHED_AT =       _PREFIX + 'batched_at'
+SEQUENCE =         _PREFIX + 'sequence'
+TABLE_VERSION =    _PREFIX + 'table_version'
+PK =               _PREFIX + 'primary_key'
+SOURCE_PK_PREFIX = _PREFIX + 'source_key_'
+LEVEL_FMT =        _PREFIX + 'level_{}_id'
+VALUE =            _PREFIX + 'value'

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -523,7 +523,7 @@ class SQLInterface:
                     mapping['to'] = canonicalized_column_name
                     mappings.append(mapping)
 
-                    log_message("Made existing column nullable. New column is nullable, existing column is not")
+                    log_message("Made existing column nullable.")
 
                     continue
 
@@ -637,12 +637,11 @@ class SQLInterface:
 
             return self._get_table_schema(connection, table_name)
 
-    def _serialize_table_record_field_name(self, remote_schema, streamed_schema, path, value_json_schema):
+    def _serialize_table_record_field_name(self, remote_schema, path, value_json_schema):
         """
         Returns the appropriate remote field (column) name for `path`.
 
         :param remote_schema: TABLE_SCHEMA(remote)
-        :param streamed_schema: TABLE_SCHEMA(local)
         :param path: (string, ...)
         :value_json_schema: dict, JSON Schema
         :return: string
@@ -762,7 +761,6 @@ class SQLInterface:
                 value = self.serialize_table_record_null_value(remote_schema, streamed_schema, path, value)
 
                 field_name = self._serialize_table_record_field_name(remote_schema,
-                                                                     streamed_schema,
                                                                      path,
                                                                      value_json_schema)
 

--- a/tests/unit/test_BufferedSingerStream.py
+++ b/tests/unit/test_BufferedSingerStream.py
@@ -2,20 +2,15 @@ from copy import deepcopy
 
 import pytest
 
-from target_postgres.singer_stream import (
-    BufferedSingerStream, SingerStreamError,
-    SINGER_BATCHED_AT,
-    SINGER_PK,
-    SINGER_RECEIVED_AT,
-    SINGER_SEQUENCE,
-    SINGER_TABLE_VERSION
-)
+from target_postgres import singer
+from target_postgres.singer_stream import BufferedSingerStream, SingerStreamError
+
 from utils.fixtures import CatStream, InvalidCatStream, CATS_SCHEMA
 
 
 def missing_sdc_properties(stream_buffer):
     errors = []
-    for p in [SINGER_BATCHED_AT, SINGER_RECEIVED_AT, SINGER_SEQUENCE, SINGER_TABLE_VERSION]:
+    for p in [singer.BATCHED_AT, singer.RECEIVED_AT, singer.SEQUENCE, singer.TABLE_VERSION]:
         if not p in stream_buffer.schema['properties']:
             errors.append({'_sdc': p,
                            'message': '`_sdc` missing'})
@@ -43,12 +38,12 @@ def test_init__empty_key_properties():
 
     assert singer_stream
     assert [] == missing_sdc_properties(singer_stream)
-    assert [SINGER_PK] == singer_stream.key_properties
+    assert [singer.PK] == singer_stream.key_properties
 
     rows_missing_pk = []
     rows_checked = 0
     for r in singer_stream.get_batch():
-        if not r[SINGER_PK]:
+        if not r[singer.PK]:
             rows_missing_pk.append(r)
 
         rows_checked += 1

--- a/tests/unit/test_denest.py
+++ b/tests/unit/test_denest.py
@@ -3,14 +3,7 @@ import random
 import pytest
 from chance import chance
 
-from target_postgres import denest
-from target_postgres import json_schema
-from target_postgres.singer_stream import (
-    SINGER_BATCHED_AT,
-    SINGER_RECEIVED_AT,
-    SINGER_SEQUENCE,
-    SINGER_TABLE_VERSION,
-)
+from target_postgres import denest, json_schema, singer
 
 
 def non_path_properties(table_batch):
@@ -265,6 +258,24 @@ def test__records__nested__child_table__a_b():
 
 
 def test__records__nested__child_table__a_b_c_e():
+    denested = denest.to_table_batches(NESTED_SCHEMA, [], NESTED_RECORDS)
+    table_batch = _get_table_batch_with_path(denested,
+                                             ('a', 'b', 'c', 'e'))
+
+    assert {'type': ['string']} == table_batch['streamed_schema']['schema']['properties'][('f',)]
+    assert {'type': ['boolean']} == table_batch['streamed_schema']['schema']['properties'][('g',)]
+
+    assert 2 == len(table_batch['records'])
+
+    for record in table_batch['records']:
+        assert 'string' == record[('f',)][0]
+        assert str == type(record[('f',)][1])
+
+        assert 'boolean' == record[('g',)][0]
+        assert bool == type(record[('g',)][1])
+
+
+def test__anyOf__():
     denested = denest.to_table_batches(NESTED_SCHEMA, [], NESTED_RECORDS)
     table_batch = _get_table_batch_with_path(denested,
                                              ('a', 'b', 'c', 'e'))

--- a/tests/unit/test_denest.py
+++ b/tests/unit/test_denest.py
@@ -245,7 +245,8 @@ def test__records__nested__child_table__a_b():
     table_batch = _get_table_batch_with_path(denested,
                                              ('a', 'b'))
 
-    assert {'type': ['integer']} == table_batch['streamed_schema']['schema']['properties'][('c', 'd')]
+    assert 1 == len(table_batch['streamed_schema']['schema']['properties'][('c', 'd')]['anyOf'])
+    assert {'type': ['integer']} == table_batch['streamed_schema']['schema']['properties'][('c', 'd')]['anyOf'][0]
 
     assert 7 == len(table_batch['records'])
 
@@ -262,8 +263,10 @@ def test__records__nested__child_table__a_b_c_e():
     table_batch = _get_table_batch_with_path(denested,
                                              ('a', 'b', 'c', 'e'))
 
-    assert {'type': ['string']} == table_batch['streamed_schema']['schema']['properties'][('f',)]
-    assert {'type': ['boolean']} == table_batch['streamed_schema']['schema']['properties'][('g',)]
+    assert 1 == len(table_batch['streamed_schema']['schema']['properties'][('f',)]['anyOf'])
+    assert {'type': ['string']} == table_batch['streamed_schema']['schema']['properties'][('f',)]['anyOf'][0]
+    assert 1 == len(table_batch['streamed_schema']['schema']['properties'][('g',)]['anyOf'])
+    assert {'type': ['boolean']} == table_batch['streamed_schema']['schema']['properties'][('g',)]['anyOf'][0]
 
     assert 2 == len(table_batch['records'])
 

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -52,7 +52,8 @@ def test_is_nullable():
 
 
 def test_is_literal():
-    assert json_schema.is_literal({'type': ['null']})
+    # null is a weird value...it _is_ a literal...but...
+    assert not json_schema.is_literal({'type': ['null']})
     assert json_schema.is_literal({'type': ['integer', 'null']})
     assert json_schema.is_literal({'type': ['integer', 'object', 'null']})
     assert json_schema.is_literal({'type': ['string']})
@@ -220,6 +221,12 @@ def test_simplify__types_into_arrays():
 
     assert \
         json_schema.simplify(
+            {'type': 'null'}
+        ) \
+        == {'type': ['null']}
+
+    assert \
+        json_schema.simplify(
             {'type': ['object'],
              'properties': {
                  'a': {'type': 'string'}}}) \
@@ -248,6 +255,9 @@ def test_simplify__complex():
             'type': ['object'],
             'properties': {
                 'every_type': {'anyOf': [
+                    {'type': ['boolean', 'null']},
+                    {'type': ['integer', 'null']},
+                    {'type': ['number', 'null']},
                     {
                         'type': ['string', 'null'],
                         'format': 'date-time'},
@@ -259,10 +269,7 @@ def test_simplify__complex():
                             'b': {'type': ['boolean']}}},
                     {
                         'type': ['array', 'null'],
-                        'items': {'type': ['integer']}},
-                    {'type': ['boolean', 'null']},
-                    {'type': ['integer', 'null']},
-                    {'type': ['number', 'null']}]}}}
+                        'items': {'type': ['integer']}}]}}}
 
     assert \
         json_schema.simplify({
@@ -633,9 +640,6 @@ def test_validation_errors__invalid_schemas():
     non_standard_schema_version = json_schema.validation_errors({'$schema': 'clearly not a valid schema version'})
     assert non_standard_schema_version
     assert not _non_string_elements(non_standard_schema_version)
-
-    only_null_schema = json_schema.validation_errors({'type': 'null'})
-    assert only_null_schema
 
 
 def test_validation_errors__invalid_draft_version():

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -112,10 +112,82 @@ def test_simplify__allOf__objects():
     ))
 
 
+
+def test_simplify__allOf__objects__merges():
+    assert \
+        json_schema.simplify({
+            'allOf': [
+                {},
+                {'properties': {'a': {'type': 'number'}}},
+                {'properties': {'c': {'type': 'integer'}}},
+                {'properties': {'b': {'type': 'string', 'format': 'date-time'}}}]
+        }) \
+        == {
+            'type': ['object'],
+            'properties': {
+                'a': {'type': ['number']},
+                'b': {'type': ['string'], 'format': 'date-time'},
+                'c': {'type': ['integer']}
+            }}
+
+
+
 def test_simplify__allOf__iterables():
     assert json_schema.is_iterable(json_schema.simplify(
         {'allOf': [{'type': 'array', 'items': {'type': 'integer'}}]}
     ))
+
+
+def test_simplify__allOf__iterables__merges():
+    '''
+    NOTE: We assume that the schemas passed into json_schema make sense. ie, there is a possible
+    way for data to _actually validate_ against them. ie, something cannot be a scalar and an
+    object at the same time, etc.
+    '''
+    assert \
+        json_schema.simplify({
+            'allOf': [
+                {'type': 'array', 'items': {
+                    'type': 'object',
+                    'properties': {
+                        'a': {'type': 'integer'}
+                }}},
+                {'type': 'array', 'items': {
+                    'type': 'object',
+                    'properties': {
+                        'c': {'type': 'string'}
+                }}},
+                {'type': 'array', 'items': {
+                    'type': 'object',
+                    'properties': {
+                        'b': {'type': 'integer'}
+                }}}]
+        }) \
+        == {
+            'type': ['array'],
+            'items': {
+                'type': ['object'],
+                'properties': {
+                    'a': {'type': ['integer']},
+                    'b': {'type': ['integer']},
+                    'c': {'type': ['string']}
+                }}}
+
+    assert \
+        json_schema.simplify({
+            'allOf': [
+                {'type': 'array', 'items': {
+                    'type': 'array',
+                    'items': {'type': 'integer'}}},
+                {'type': 'array', 'items': {
+                    'type': 'array',
+                    'items': {'type': ['number', 'null']}}}]
+        }) \
+        == {
+            'type': ['array'],
+            'items': {
+                'type': ['array'],
+                'items': {'type': ['number', 'null']}}}
 
 
 def test_simplify__allOf__picks_scalars():

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -371,11 +371,12 @@ def test_simplify__anyOf__datetimes_dont_merge_with_strings():
                     {"type": ["string", "null"]}]}) \
         == {
                 "anyOf": [
-                    {"type": ["string", "null"]},
                     {
                         "type": ["string", 'null'],
                         "format": "date-time"
-                    }]}
+                    },
+                    {"type": ["string", "null"]}]}
+
 
 def test_simplify__anyOf__single_nullable_makes_all_nullable():
     assert \
@@ -391,15 +392,14 @@ def test_simplify__anyOf__single_nullable_makes_all_nullable():
             ]}
         ) \
         == {'anyOf': [
-                {'type': ['boolean', 'null']},
-                {'type': ['integer', 'null']},
-                {'type': ['number', 'null']},
-                {'type': ['string', 'null']},
                 {
                     'type': ['string', 'null'],
                     'format': 'date-time'
-                }
-            ]}
+                },
+                {'type': ['boolean', 'null']},
+                {'type': ['integer', 'null']},
+                {'type': ['number', 'null']},
+                {'type': ['string', 'null']}]}
 
 
 def test_simplify__anyOf__objects__no_overlapping_keys():
@@ -424,6 +424,7 @@ def test_simplify__anyOf__objects__no_overlapping_keys():
                 'c': {'type': ['string']}
             }
         }
+
 
 def test_simplify__anyOf__objects__overlapping_keys():
     assert \
@@ -492,20 +493,20 @@ def test_simplify__complex():
             'properties': {
                 'every_type': {'anyOf': [
                     {
+                        'type': ['string', 'null'],
+                        'format': 'date-time'},
+                    {
                         'type': ['array', 'null'],
                         'items': {'type': ['integer']}},
-                    {'type': ['boolean', 'null']},
-                    {'type': ['integer', 'null']},
-                    {'type': ['number', 'null']},
                     {
                         'type': ['object', 'null'],
                         'properties': {
                             'i': {'type': ['integer']},
                             'n': {'type': ['number']},
                             'b': {'type': ['boolean']}}},
-                    {
-                        'type': ['string', 'null'],
-                        'format': 'date-time'}]}}}
+                    {'type': ['boolean', 'null']},
+                    {'type': ['integer', 'null']},
+                    {'type': ['number', 'null']}]}}}
 
     assert \
         json_schema.simplify({

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -52,7 +52,9 @@ def test_is_nullable():
 
 
 def test_is_literal():
+    assert json_schema.is_literal({'type': ['null']})
     assert json_schema.is_literal({'type': ['integer', 'null']})
+    assert json_schema.is_literal({'type': ['integer', 'null', 'object']})
     assert json_schema.is_literal({'type': ['string']})
     assert not json_schema.is_literal({'type': ['array'], 'items': {'type': ['boolean']}})
     assert not json_schema.is_literal({})

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -37,6 +37,9 @@ def test_is_object():
     assert json_schema.is_object({'type': ['object']})
     assert json_schema.is_object({'properties': {}})
     assert json_schema.is_object({})
+    assert not json_schema.is_object({'anyOf': [
+        {'type': ['object', 'null'], 'properties': {'i': {'type': ['integer']}}},
+        {'type': ['string', 'null'], 'format': 'date-time'}]})
 
 
 def test_is_iterable():


### PR DESCRIPTION
# Motivation

#14 

This pr seeks to add _full_ support for `anyOf` to `Target-Postgres`.

`anyOf` clauses are merged/simplified according to the following rules (these _are_ recursive):
- all literals are dedupped
- all objects are merged into the same object schema, with sub-schemas being grouped as simplified `anyOf` schemas
- all iterables' `items` schemas are merged as simplified `anyOf` schemas
- all `anyOf`s are flattened to the topmost
- if there is only a single element in an `anyOf`, that is denested
- if any `anyOf`s are nullable, all are nullable

We also simplify "implicit" `anyOf`s. These are the literal schemas where the `type` field is overloaded with multiple types. ie, something like `"type": ["string", "integer"]`