### PR TITLE
Use a faster method to check if a table has any rows

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -768,11 +768,11 @@ class PostgresTarget(SQLInterface):
             return []
 
     def is_table_empty(self, cur, table_name):
-        cur.execute(sql.SQL('SELECT COUNT(1) FROM {}.{};').format(
+        cur.execute(sql.SQL('SELECT EXISTS (SELECT * FROM {}.{});').format(
             sql.Identifier(self.postgres_schema),
             sql.Identifier(table_name)))
 
-        return cur.fetchall()[0][0] == 0
+        return not cur.fetchall()[0][0]
 
     def get_table_schema(self, cur, name):
         return self.__get_table_schema(cur, name)


### PR DESCRIPTION
We noticed some slow COUNT(1) queries coming from target-postgres. I believe this method checking for table emptiness is the culprit. Because we only care if there are any rows at all, we don't actually need to count all the rows, and can just check for the existence of any. PG has a handy `exists` keyword for this, so we can do that instead!

Before, with the count query like `select count(1) from raw_tap_shopify.orders;` here's the explain:

```
Finalize Aggregate  (cost=553053.72..553053.73 rows=1 width=8)
  ->  Gather  (cost=553053.50..553053.71 rows=2 width=8)
        Workers Planned: 2
        ->  Partial Aggregate  (cost=552053.50..552053.51 rows=1 width=8)
              ->  Parallel Seq Scan on orders  (cost=0.00..549615.20 rows=975320 width=0)
JIT:
  Functions: 4
  Options: Inlining true, Optimization true, Expressions true, Deforming true
```

Note the full table scan.

After this change, with the exists query like `select exists (select * from raw_tap_shopify.orders);` here's the explain:

```
Result  (cost=0.24..0.25 rows=1 width=1)
  InitPlan 1 (returns $0)
    ->  Seq Scan on orders  (cost=0.00..563269.69 rows=2340769 width=0)
```

Woop woop! I believe this feature is also supported on Redshift, so this change should be safe to apply downstream as well. (https://docs.aws.amazon.com/redshift/latest/dg/r_exists_condition.html)