### PR TITLE
Fix: Merge conflict of bio test and anyOf test

### DIFF
--- a/tests/unit/test_postgres.py
+++ b/tests/unit/test_postgres.py
@@ -365,6 +365,7 @@ def test_loading__simple__anyOf(db_cleanup):
                                      ('age', 'bigint', 'YES'),
                                      ('id', 'bigint', 'NO'),
                                      ('name', 'text', 'NO'),
+                                     ('bio', 'text', 'NO'),
                                      ('paw_size', 'bigint', 'NO'),
                                      ('paw_colour', 'text', 'NO'),
                                      ('flea_check_complete', 'boolean', 'NO'),


### PR DESCRIPTION
# Motivation

Tests in master are borked due to merging two disjoint branches which didn't conflict with each other, but slightly messed with each others tests. Clearly a simple fix.