### PR TITLE
add None check for self.key_properties

### DIFF
--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -96,7 +96,7 @@ class BufferedSingerStream():
                 'format': 'date-time'
             }
 
-        if len(self.key_properties) == 0:
+        if self.key_properties is None or len(self.key_properties) == 0:
             self.use_uuid_pk = True
             self.key_properties = [singer.PK]
             properties[singer.PK] = {


### PR DESCRIPTION
When BufferedSingerStream is instantiated, it [updates the schema](https://github.com/datamill-co/target-postgres/blob/master/target_postgres/singer_stream.py#L47). It passes the `key_properties` value that was passed to the constructor, which is [set to None if the SCHEMA message doesn't contain a key_properties key](https://github.com/datamill-co/target-postgres/blob/master/target_postgres/target_tools.py#L119-L120). 

If `self.key_properties` is `None` then the conditional I've changed will throw an error because `len(None)` is an invalid statement.

I don't know enough about Singer to know why key_properties would ever be null/None in a SCHEMA message, but I had it happen to me when developing a custom tap and the code in this target indicates that it's possible to happen in other situations, so this check is safer.