### PR TITLE
Fix decimal precision (decimal.InvalidOperation decimal.DivisionImpossible error)

### DIFF
--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -67,6 +67,7 @@ class BufferedSingerStream():
     def update_schema(self, schema, key_properties):
         # In order to determine whether a value _is in_ properties _or not_ we need to flatten `$ref`s etc.
         self.schema = json_schema.simplify(schema)
+        json_schema.walk_schema_for_numeric_precision(schema)
         self.key_properties = deepcopy(key_properties)
 
         # The validator can handle _many_ more things than our simplified schema, and is, in general handled by third party code

--- a/tests/unit/test_target_tools.py
+++ b/tests/unit/test_target_tools.py
@@ -154,6 +154,52 @@ def test_record_with_multiple_of():
     assert rows_persisted == expected_rows
 
 
+def test_record_with_target_postgres_precision():
+    values = [1, 1.0, 2, 2.0, 3, 7, 10.1]
+    records = []
+    for value in values:
+        records.append({
+            "type": "RECORD",
+            "stream": "test",
+            "record": {"multipleOfKey": value},
+        })
+
+    class TestStream(ListStream):
+        stream = [
+            {
+                "type": "SCHEMA",
+                "stream": "test",
+                "schema": {
+                    "properties": {
+                        "multipleOfKey": {
+                            "type": [
+                            "null",
+                            "number"
+                            ],
+                            "exclusiveMaximum": True,
+                            "maximum": 100000000000000000000000000000000000000000000000000000000000000,
+                            "multipleOf": 1e-38,
+                            "exclusiveMinimum": True,
+                            "minimum": -100000000000000000000000000000000000000000000000000000000000000
+                        }
+                    }
+                },
+                "key_properties": []
+            }
+        ] + records
+
+    target = Target()
+
+    target_tools.stream_to_target(TestStream(), target, config=CONFIG.copy())
+
+    expected_rows = len(records)
+    rows_persisted = 0
+    for call in target.calls['write_batch']:
+        rows_persisted += call['records_count']
+
+    assert rows_persisted == expected_rows
+
+
 def test_state__capture(capsys):
     stream = [
         json.dumps({'type': 'STATE', 'value': {'test': 'state-1'}}),


### PR DESCRIPTION
# Problem

Error message (this is from target-snowflake but the problem is in the shared code):

```
target-snowflake   | CRITICAL [<class 'decimal.DivisionImpossible'>]
target-snowflake   | INFO MillisLoggingCursor: 72 millis spent executing: ROLLBACK
target-snowflake   | Traceback (most recent call last):
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/bin/target-snowflake", line 8, in <module>
target-snowflake   |     sys.exit(cli())
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_snowflake/__init__.py", line 57, in cli
target-snowflake   |     main(args.config)
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_snowflake/__init__.py", line 51, in main
target-snowflake   |     target_tools.main(target)
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_postgres/target_tools.py", line 28, in main
target-snowflake   |     stream_to_target(input_stream, target, config=config)
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_postgres/target_tools.py", line 77, in stream_to_target
target-snowflake   |     raise e
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_postgres/target_tools.py", line 64, in stream_to_target
target-snowflake   |     line
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_postgres/target_tools.py", line 141, in _line_handler
target-snowflake   |     state_tracker.handle_record_message(line_data['stream'], line_data)
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_postgres/stream_tracker.py", line 63, in handle_record_message
target-snowflake   |     self.streams[stream].add_record_message(line_data)
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/target_postgres/singer_stream.py", line 145, in add_record_message
target-snowflake   |     self.validator.validate(record_message['record'])
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 129, in validate
target-snowflake   |     for error in self.iter_errors(*args, **kwargs):
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 105, in iter_errors
target-snowflake   |     for error in errors:
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/jsonschema/_validators.py", line 304, in properties_draft4
target-snowflake   |     schema_path=property,
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 121, in descend
target-snowflake   |     for error in self.iter_errors(instance, schema):
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/jsonschema/validators.py", line 105, in iter_errors
target-snowflake   |     for error in errors:
target-snowflake   |   File "/project/.meltano/loaders/target-snowflake/venv/lib/python3.7/site-packages/jsonschema/_validators.py", line 127, in multipleOf
target-snowflake   |     failed = instance % dB
target-snowflake   | decimal.InvalidOperation: [<class 'decimal.DivisionImpossible'>]
meltano            | Loading failed (1): decimal.InvalidOperation: [<class 'decimal.DivisionImpossible'>]
meltano            | ELT could not be completed: Loader failed
ELT could not be completed: Loader failed
```

The problem is that [Singer's offical `tap-postgres`](https://github.com/singer-io/tap-postgres) uses [`minimum`, `maximum`, and `multipleOf` to effectively report the scale of the column](https://github.com/singer-io/tap-postgres/blob/master/tap_postgres/__init__.py#L112-L115).

For example,

```
{
  "type": "SCHEMA",
  "stream": "foobar",
  "schema": {
    "type": "object",
    "properties": {
      "id": {
        "type": ["integer"],
        "minimum": -2147483648,
        "maximum": 2147483647
      },
      "sample_numeric": {
        "type": ["null", "number"],
        "exclusiveMaximum": true,
        "maximum": 100000000000000000000000000000000000000000000000000000000000000,
        "multipleOf": 1E-38,
        "exclusiveMinimum": true,
        "minimum": -100000000000000000000000000000000000000000000000000000000000000
      }
    }
  },
  "key_properties": ["id"],
  "bookmark_properties": []
}

{
  "type": "RECORD",
  "stream": "foobar",
  "record": {
    "id": 1,
    "sample_numeric": 0.000913808181253534
  },
  "version": 1596488217992,
  "time_extracted": "2020-08-03T20:56:57.992931Z"
}
```

This breaks JSON schema validation as when validating `multipleOf` it tries to do `Decimal('0.000913808181253534') % Decimal('1E-38')`, as the default decimal precision in python is too small (28 I believe).

# Solution

This is a well-known problem that has bitten several targets, for which there are several solutions. One is simply to set the precision to something arbitrarily high, like 40. Another, which the [`pipelinewise-target-postgres`](https://github.com/transferwise/pipelinewise-target-postgres) does, is to simply [not allow precision higher than some threshold](https://github.com/transferwise/pipelinewise-target-postgres/blob/master/target_postgres/__init__.py#L123-L130).

Here, I ported [a solution](https://github.com/meltano/target-postgres/pull/6) I wrote for [`meltano/target-postgres`](https://github.com/meltano/target-postgres) which sets Python's decimal precision to as large as it needs to be to match the schema. This solution was [later ported to `meltano/target-snowflake`](https://gitlab.com/meltano/target-snowflake/-/merge_requests/34). Open to other solutions though. I would request that any solution also be ported to target-snowflake.