### PR TITLE
Adding correct error output for key_properties type change error

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -257,9 +257,11 @@ class PostgresTarget(SQLInterface):
                         if self.json_schema_to_sql_type(remote_column_schema) \
                                 != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
                             raise PostgresError(
-                                ('`key_properties` type change detected for "{}". ' +
+                                ('`key_properties` type change detected for "{}.{}.{}". ' +
                                  'Current, streamed, remote json schema: {}, {}, {}. ' +
                                  'Current, streamed, remote sql types: `{}`, `{}`, `{}`').format(
+                                    self.postgres_schema,
+                                    root_table_name,
                                     key_property,
                                     json_schema.get_type(current_table_schema['schema']['properties'][key_property]),
                                     json_schema.get_type(stream_buffer.schema['properties'][key_property]),

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -258,14 +258,16 @@ class PostgresTarget(SQLInterface):
                                 != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
                             raise PostgresError(
                                 ('`key_properties` type change detected for "{}". ' +
-                                 'Existing values are: {}. ' +
-                                 'Streamed values are: {}, {}, {}').format(
+                                 'Current, streamed, remote json schema: {}, {}, {}. ' +
+                                 'Current, streamed, remote sql types: `{}`, `{}`, `{}`').format(
                                     key_property,
                                     json_schema.get_type(current_table_schema['schema']['properties'][key_property]),
                                     json_schema.get_type(stream_buffer.schema['properties'][key_property]),
+                                    json_schema.get_type(remote_column_schema),
                                     self.json_schema_to_sql_type(
                                         current_table_schema['schema']['properties'][key_property]),
-                                    self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property])
+                                    self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]),
+                                    self.json_schema_to_sql_type(remote_column_schema)
                                 ))
 
                 target_table_version = current_table_version or stream_buffer.max_version

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -788,6 +788,8 @@ class PostgresTarget(SQLInterface):
 
         properties = {}
         for column in cur.fetchall():
+            self.LOGGER.info('schema, table, col, type, nullable: {}, {}, {}, {}, {}'.format(
+                self.postgres_schema, name, column[0], column[1], column[2]))
             properties[column[0]] = self.sql_type_to_json_schema(column[1], column[2] == 'YES')
 
         metadata = self._get_table_metadata(cur, name)


### PR DESCRIPTION
The previous error message for the `key_properties type change detected` exception did not include the `remote_column_schema` value, which is the one actually used for comparison in the preceding if statement. Also, the the error message was worded in a confusing way because one of the three values after the "streamed values" part of the error message is actually the SQL type for the existing value.

This change cleans up the error reporting and includes all the relevant values.