### PR TITLE
Use `psycopg2-binary` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_postgres'],
     install_requires=[
         'arrow==0.15.5',
-        'psycopg2==2.8.5',
+        'psycopg2-binary==2.8.5',
         'singer-python==5.9.0'
     ],
     setup_requires=[


### PR DESCRIPTION
https://pypi.org/project/psycopg2-binary/

By using the non-binary version of the package all consumers of the package (including those with transitive dependencies on it) need to have compilation toolchain installed along with `libpq-dev`, and several other system-level dependencies. This significantly limits portability, and is a frequent source of issues.

Though Psycopg advises users to compile their Python library from source instead of using the binary (i.e. pre-built) version for production use-cases, their binary package is widely used in production use-cases without issue. Within the Singer ecosystem it's used by other Postgres targets, such as [the Transferwise variant](https://github.com/transferwise/pipelinewise-target-postgres/blob/e060d44c376095a9c8ae1a731f548ab9aa16c2f3/setup.py#L22)

The Python ecosystem as a whole is thankfully starting to move away from the expectation that users should run arbitrary code from dependencies at install-time, generally to compile Python extension modules. It would be nice if Data Mill's `target-postgres` could use `psycopg2-binary` to enable its users to use pre-built wheels rather than having to build them themselves.