### PR TITLE
Updating singer_stream.py to allow schemas without properties

### DIFF
--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -71,7 +71,11 @@ class BufferedSingerStream():
 
         # The validator can handle _many_ more things than our simplified schema, and is, in general handled by third party code
         self.validator = Draft4Validator(schema, format_checker=FormatChecker())
-
+        
+        # Some taps do not provide 'properties' key, which causes the next block to fail
+        if not (self.schema and 'properties' in self.schema):
+            return
+        
         properties = self.schema['properties']
 
         if singer.RECEIVED_AT not in properties:


### PR DESCRIPTION
While utilizing tap-zendesk (https://github.com/twilio-labs/twilio-tap-zendesk) there are some cases where the generated schema does not include a `properties` key in the dictionary, causing the `properties = self.schema['properties']` to fail.

Given that there is nothing returned from this function, returning early appears to resolve it.