### PR TITLE
Change psycopg depedency from binary to source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ packages = [{include = "target_postgres"}]
 python = ">=3.7"
 arrow = "^1.2.3"
 psycopg2-binary = "^2.9.5"
-singer-python = "^5.9.0"
+singer-python = {git = "https://github.com/peliqan-io/singer-python", branch = "master"}
 
 [tool.poetry.group.tests]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [{include = "target_postgres"}]
 [tool.poetry.dependencies]
 python = ">=3.7"
 arrow = "^1.2.3"
-psycopg2-binary = "^2.9.5"
+psycopg2 = "^2.9.5"
 singer-python = {git = "https://github.com/peliqan-io/singer-python", branch = "master"}
 
 [tool.poetry.group.tests]


### PR DESCRIPTION
Due to a [version issue](https://github.com/psycopg/psycopg2/issues/1360), binary package of `psycopg2` was replaced by source package.