### PR TITLE
Adds bookmark_properties ordering in _get_update_sql to prevent older data in same batch from overriding newer data

### DIFF
--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -63,6 +63,9 @@ def _get_streamed_table_schemas(schema, key_properties, bookmark_properties):
 
 
 def _to_table_schema(path, level, keys, bookmarks, properties):
+    bookmarks = bookmarks or []
+    keys = keys or []
+
     for key in keys:
         if not (key,) in properties:
             raise Exception('Unknown key "{}" found for table "{}". Known fields are: {}'.format(

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -596,9 +596,10 @@ class PostgresTarget(SQLInterface):
         canonicalized_key_properties = [self.fetch_column_from_path((key_property,), remote_schema)[0]
                                         for key_property in remote_schema['key_properties']]
 
-        canonicalized_bookmark_properties = [self.fetch_column_from_path((bookmark_property,), remote_schema)[0]
-                                            for bookmark_property in remote_schema['bookmark_properties']
-                                            if 'bookmark_properties' in remote_schema]
+        canonicalized_bookmark_properties = []
+        if 'bookmark_properties' in remote_schema:
+            for bookmark_property in remote_schema['bookmark_properties']:
+                canonicalized_bookmark_properties.append(self.fetch_column_from_path((bookmark_property,), remote_schema)[0])
 
         update_sql = self._get_update_sql(remote_schema['name'],
                                           temp_table_name,

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -597,7 +597,8 @@ class PostgresTarget(SQLInterface):
                                         for key_property in remote_schema['key_properties']]
 
         canonicalized_bookmark_properties = [self.fetch_column_from_path((bookmark_property,), remote_schema)[0]
-                                            for bookmark_property in remote_schema['bookmark_properties']]
+                                            for bookmark_property in remote_schema['bookmark_properties']
+                                            if 'bookmark_properties' in remote_schema]
 
         update_sql = self._get_update_sql(remote_schema['name'],
                                           temp_table_name,

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -31,6 +31,7 @@ class BufferedSingerStream():
                  stream,
                  schema,
                  key_properties,
+                 bookmark_properties,
                  *args,
                  invalid_records_detect=None,
                  invalid_records_threshold=None,
@@ -43,8 +44,9 @@ class BufferedSingerStream():
         """
         self.schema = None
         self.key_properties = None
+        self.bookmark_properties = None
         self.validator = None
-        self.update_schema(schema, key_properties)
+        self.update_schema(schema, key_properties, bookmark_properties)
 
         self.stream = stream
         self.invalid_records = []
@@ -64,10 +66,11 @@ class BufferedSingerStream():
         self.__size = 0
         self.__lifetime_max_version = None
 
-    def update_schema(self, schema, key_properties):
+    def update_schema(self, schema, key_properties, bookmark_properties):
         # In order to determine whether a value _is in_ properties _or not_ we need to flatten `$ref`s etc.
         self.schema = json_schema.simplify(schema)
         self.key_properties = deepcopy(key_properties)
+        self.bookmark_properties = deepcopy(bookmark_properties)
 
         # The validator can handle _many_ more things than our simplified schema, and is, in general handled by third party code
         self.validator = Draft4Validator(schema, format_checker=FormatChecker())

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -226,6 +226,16 @@ class SQLInterface:
         """
         raise NotImplementedError('`add_key_properties` not implemented.')
 
+    def add_bookmark_properties(self, connection, table_name, bookmark_properties):
+        """
+
+        :param connection: remote connection, type left to be determined by implementing class
+        :param table_name: string
+        :param bookmark_properties: [string, ...]
+        :return: None
+        """
+        raise NotImplementedError('`add_bookmark_properties` not implemented.')
+
     def add_table_mapping_helper(self, from_path, table_mappings):
         """
 
@@ -404,6 +414,7 @@ class SQLInterface:
                 existing_table = False
 
             self.add_key_properties(connection, table_name, schema.get('key_properties', None))
+            self.add_bookmark_properties(connection, table_name, schema.get('bookmark_properties', None))
 
             ## Build up mappings to compare new columns against existing
             mappings = []
@@ -791,7 +802,7 @@ class SQLInterface:
         """
         raise NotImplementedError('`write_table_batch` not implemented.')
 
-    def write_batch_helper(self, connection, root_table_name, schema, key_properties, records, metadata):
+    def write_batch_helper(self, connection, root_table_name, schema, key_properties, bookmark_properties, records, metadata):
         """
         Write all `table_batch`s associated with the given `schema` and `records` to remote.
 
@@ -816,7 +827,7 @@ class SQLInterface:
                     key_properties
                 ))
 
-                for table_batch in denest.to_table_batches(schema, key_properties, records):
+                for table_batch in denest.to_table_batches(schema, key_properties, bookmark_properties, records):
                     table_batch['streamed_schema']['path'] = (root_table_name,) + \
                                                              table_batch['streamed_schema']['path']
 

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -119,10 +119,16 @@ def _line_handler(state_tracker, target, invalid_records_detect, invalid_records
         else:
             key_properties = None
 
+        if 'bookmark_properties' in line_data:
+            bookmark_properties = line_data['bookmark_properties']
+        else:
+            bookmark_properties = None
+
         if stream not in state_tracker.streams:
             buffered_stream = BufferedSingerStream(stream,
                                                    schema,
                                                    key_properties,
+                                                   bookmark_properties,
                                                    invalid_records_detect=invalid_records_detect,
                                                    invalid_records_threshold=invalid_records_threshold)
             if max_batch_rows:
@@ -132,7 +138,7 @@ def _line_handler(state_tracker, target, invalid_records_detect, invalid_records
 
             state_tracker.register_stream(stream, buffered_stream)
         else:
-            state_tracker.streams[stream].update_schema(schema, key_properties)
+            state_tracker.streams[stream].update_schema(schema, key_properties, bookmark_properties)
     elif line_data['type'] == 'RECORD':
         if 'stream' not in line_data:
             raise TargetError('`stream` is a required key: {}'.format(line))


### PR DESCRIPTION
### Issue

When a tap streams data which could have the updates to the same id in a short timespan that is included in the same upsert batch, the older data is prioritized and upserted instead of the new data that appears later in the batch. I am currently seeing this behavior when doing full syncs using tap-chargebee and have reproduced the issue with a sample set of 5 records with 1 record being an update. 

### Solution

I have updated the _get_update_sql function to use bookmark properties to add a secondary order to the primary keys to prioritize new records over older records.