### PR TITLE
feat(HGI-4773): improve target performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ ENV/
 /venv--*
 /venv
 /tests/migrations/artifacts
+.secrets
+.venv

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent {label 'linux'}
+    stages {
+        stage('Deploy connector') {
+            steps {
+                sh('cd /var/lib/jenkins/ && ./deploy-connector.sh')
+            }
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_postgres'],
     install_requires=[
         'arrow==0.15.5',
-        'psycopg2',
+        'psycopg2-binary==2.9.3',
         'singer-python==5.9.0'
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name='singer-target-postgres',
     url='https://github.com/datamill-co/target-postgres',
     author='datamill',
-    version="0.2.4",
+    version="0.2.5",
     description='Singer.io target for loading data into postgres',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['target_postgres'],
     install_requires=[
         'arrow==0.15.5',
-        'psycopg2==2.8.5',
+        'psycopg2',
         'singer-python==5.9.0'
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     classifiers=['Programming Language :: Python :: 3 :: Only'],
     py_modules=['target_postgres'],
     install_requires=[
-        'arrow==0.15.5',
+        'arrow==1.2.3',
         'psycopg2-binary==2.9.3',
         'singer-python==5.9.0',
         'udatetime==0.0.17',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
     install_requires=[
         'arrow==0.15.5',
         'psycopg2-binary==2.9.3',
-        'singer-python==5.9.0'
+        'singer-python==5.9.0',
+        'udatetime==0.0.17',
+        'ujson==5.11.0'
     ],
     setup_requires=[
         "pytest-runner"

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -581,7 +581,7 @@ def _type_shorthand(type_s):
 
 
 def shorthand(schema):
-    t = deepcopy(get_type(schema))
+    t = ujson.loads(ujson.dumps(get_type(schema)))
 
     if 'format' in schema and 'date-time' == schema['format'] and STRING in t:
         t.remove(STRING)

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 import decimal
 import json
 import re
+import ujson
 
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import SchemaError
@@ -52,7 +53,7 @@ def get_type(schema):
     if isinstance(t, str):
         return [t]
 
-    return deepcopy(t)
+    return ujson.loads(ujson.dumps(t))
 
 
 def simple_type(schema):

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -597,7 +597,7 @@ class PostgresTarget(SQLInterface):
                 row = next(rows_iter)
 
                 with io.StringIO() as out:
-                    writer = csv.DictWriter(out, csv_headers)
+                    writer = csv.DictWriter(out, csv_headers, escapechar='\\')
                     writer.writerow(row)
                     return out.getvalue()
             except StopIteration:

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -551,7 +551,7 @@ class PostgresTarget(SQLInterface):
             datetime_str = udatetime.to_string(udatetime.from_string(value))
             return datetime_str[:24] + datetime_str[26:]
         except Exception as e:
-            self.LOGGER.info(f'Error serializing datetime value: {value} with udatetime. Falling back to arrow.')
+            # fall back to arrow in case udatetime couldn't parse the date
             return arrow.get(value).format('YYYY-MM-DD HH:mm:ss.SSSSZZ')
 
     def persist_csv_rows(self,

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -9,6 +9,7 @@ import uuid
 import hashlib
 
 import arrow
+import udatetime
 from psycopg2 import sql
 from psycopg2.extras import LoggingConnection, LoggingCursor
 
@@ -546,7 +547,12 @@ class PostgresTarget(SQLInterface):
         return value
 
     def serialize_table_record_datetime_value(self, remote_schema, streamed_schema, field, value):
-        return arrow.get(value).format('YYYY-MM-DD HH:mm:ss.SSSSZZ')
+        try:
+            datetime_str = udatetime.to_string(udatetime.from_string(value))
+            return datetime_str[:24] + datetime_str[26:]
+        except Exception as e:
+            self.LOGGER.info(f'Error serializing datetime value: {value} with udatetime. Falling back to arrow.')
+            return arrow.get(value).format('YYYY-MM-DD HH:mm:ss.SSSSZZ')
 
     def persist_csv_rows(self,
                          cur,

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -549,6 +549,7 @@ class PostgresTarget(SQLInterface):
     def serialize_table_record_datetime_value(self, remote_schema, streamed_schema, field, value):
         try:
             datetime_str = udatetime.to_string(udatetime.from_string(value))
+            # remove some characters to make it 'YYYY-MM-DD HH:mm:ss.SSSSZZ'
             return datetime_str[:24] + datetime_str[26:]
         except Exception as e:
             # fall back to arrow in case udatetime couldn't parse the date

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -182,7 +182,7 @@ class BufferedSingerStream():
             if 'sequence' in record_message:
                 record[singer.SEQUENCE] = record_message['sequence']
             else:
-                record[singer.SEQUENCE] = arrow.get().timestamp
+                record[singer.SEQUENCE] = arrow.get().int_timestamp
 
             records.append(record)
 

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-import json
+import ujson
 import uuid
 
 import arrow
@@ -23,7 +23,7 @@ RAW_LINE_SIZE = '__raw_line_size'
 
 
 def get_line_size(line_data):
-    return line_data.get(RAW_LINE_SIZE) or len(json.dumps(line_data))
+    return line_data.get(RAW_LINE_SIZE) or len(ujson.dumps(line_data))
 
 
 class BufferedSingerStream():

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -36,6 +36,7 @@ class BufferedSingerStream():
                  invalid_records_threshold=None,
                  max_rows=200000,
                  max_buffer_size=104857600,  # 100MB
+                 skip_records_validation=False,
                  **kwargs):
         """
         :param invalid_records_detect: Defaults to True when value is None
@@ -53,6 +54,8 @@ class BufferedSingerStream():
 
         self.invalid_records_detect = invalid_records_detect
         self.invalid_records_threshold = invalid_records_threshold
+
+        self.skip_records_validation = skip_records_validation
 
         if self.invalid_records_detect is None:
             self.invalid_records_detect = True
@@ -142,7 +145,8 @@ class BufferedSingerStream():
             return None
 
         try:
-            self.validator.validate(record_message['record'])
+            if not self.skip_records_validation:
+                self.validator.validate(record_message['record'])
         except ValidationError as error:
             add_record = False
             self.invalid_records.append((error, record_message))

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -726,6 +726,8 @@ class SQLInterface:
         default_row = dict([(field, NULL_DEFAULT) for field in remote_fields])
 
         paths = streamed_schema['schema']['properties'].keys()
+        field_names_cache = {}
+        
         for record in records:
 
             row = ujson.loads(ujson.dumps(default_row))
@@ -748,17 +750,23 @@ class SQLInterface:
                         and value is not None:
                     value = self.serialize_table_record_datetime_value(remote_schema, streamed_schema, path,
                                                                        value)
+                    field_cache_key = f"{path}_datetime_format"
                     value_json_schema = {'type': json_schema.STRING,
                                          'format': json_schema.DATE_TIME_FORMAT}
                 else:
+                    field_cache_key = f"{path}_type"
                     value_json_schema = {'type': json_schema_string_type}
 
                 ## Serialize NULL default value
                 value = self.serialize_table_record_null_value(remote_schema, streamed_schema, path, value)
 
-                field_name = self._serialize_table_record_field_name(remote_schema,
+                if field_cache_key in field_names_cache:
+                    field_name = field_names_cache[field_cache_key]
+                else:
+                    field_name = self._serialize_table_record_field_name(remote_schema,
                                                                      path,
                                                                      value_json_schema)
+                    field_names_cache[field_cache_key] = field_name
 
                 ## `field_name` is unset
                 if row[field_name] == NULL_DEFAULT:

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -15,6 +15,7 @@
 from copy import deepcopy
 import time
 
+import ujson
 import singer
 import singer.metrics as metrics
 
@@ -727,7 +728,7 @@ class SQLInterface:
         paths = streamed_schema['schema']['properties'].keys()
         for record in records:
 
-            row = deepcopy(default_row)
+            row = ujson.loads(ujson.dumps(default_row))
 
             for path in paths:
                 json_schema_string_type, value = record.get(path, (None, None))

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -5,6 +5,7 @@ import pkg_resources
 import sys
 import threading
 import decimal
+import ujson
 
 import singer
 from singer import utils, metadata, metrics
@@ -91,8 +92,8 @@ def _report_invalid_records(streams):
 def _line_handler(state_tracker, target, invalid_records_detect, invalid_records_threshold, max_batch_rows,
                   max_batch_size, line):
     try:
-        line_data = json.loads(line, parse_float=decimal.Decimal)
-    except json.decoder.JSONDecodeError:
+        line_data = ujson.loads(line)
+    except ujson.JSONDecodeError:
         LOGGER.error("Unable to parse JSON: {}".format(line))
         raise
 

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -53,6 +53,7 @@ def stream_to_target(stream, target, config={}):
         max_batch_rows = config.get('max_batch_rows', 200000)
         max_batch_size = config.get('max_batch_size', 104857600)  # 100MB
         batch_detection_threshold = config.get('batch_detection_threshold', max(max_batch_rows / 40, 50))
+        skip_records_validation = config.get('skip_records_validation', False)
 
         line_count = 0
         for line in stream:
@@ -62,7 +63,8 @@ def stream_to_target(stream, target, config={}):
                           invalid_records_threshold,
                           max_batch_rows,
                           max_batch_size,
-                          line
+                          line,
+                          skip_records_validation
                           )
             if line_count > 0 and line_count % batch_detection_threshold == 0:
                 state_tracker.flush_streams()
@@ -90,7 +92,7 @@ def _report_invalid_records(streams):
 
 
 def _line_handler(state_tracker, target, invalid_records_detect, invalid_records_threshold, max_batch_rows,
-                  max_batch_size, line):
+                  max_batch_size, line, skip_records_validation):
     try:
         line_data = ujson.loads(line)
     except ujson.JSONDecodeError:
@@ -125,7 +127,8 @@ def _line_handler(state_tracker, target, invalid_records_detect, invalid_records
                                                    schema,
                                                    key_properties,
                                                    invalid_records_detect=invalid_records_detect,
-                                                   invalid_records_threshold=invalid_records_threshold)
+                                                   invalid_records_threshold=invalid_records_threshold,
+                                                   skip_records_validation=skip_records_validation)
             if max_batch_rows:
                 buffered_stream.max_rows = max_batch_rows
             if max_batch_size:


### PR DESCRIPTION
- use `udatetime` instead of `arrow` to parse record's `datetime` fields
- use `ujson` instead of `json` for serialization/deserialization
- cache record fields to database schema mapping
- add flag `skip_records_validation` to make record validation optional (default is to validate)